### PR TITLE
ci: add autonomous agent workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-spec.yml
+++ b/.github/ISSUE_TEMPLATE/agent-spec.yml
@@ -1,0 +1,58 @@
+name: Agent Spec
+description: Hand a fully scoped implementation spec to the autonomous agent workflow.
+title: "[agent-spec]: "
+labels:
+  - agent:ready
+  - agent:spec
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Write the spec as if another engineer will implement it without follow-up.
+        The agent workflow starts when this issue has the `agent:ready` label.
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should be true when this work is done?
+      placeholder: Build...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Concrete checks the agent and reviewer should use.
+      placeholder: |
+        - ...
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Include intended files/apps/packages and anything explicitly out of scope.
+      placeholder: |
+        In scope:
+        Out of scope:
+    validations:
+      required: true
+  - type: textarea
+    id: tests
+    attributes:
+      label: Required Tests
+      description: Tell the agent what to run or add.
+      placeholder: |
+        - pnpm lint
+        - pnpm typecheck
+        - pnpm test
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Design notes, links, screenshots, migration constraints, rollout notes.
+    validations:
+      required: false

--- a/.github/workflows/agent-automerge.yml
+++ b/.github/workflows/agent-automerge.yml
@@ -1,0 +1,33 @@
+name: Agent Auto Merge
+
+on:
+  pull_request_target:
+    types: [labeled, ready_for_review, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to auto-merge.
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    name: Enable guarded auto-merge
+    if: |
+      vars.AGENT_AUTOMERGE_ENABLED == 'true' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'agent:auto-merge')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable GitHub auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          gh pr merge "$PR_NUMBER" --repo "$REPOSITORY" --squash --auto --delete-branch

--- a/.github/workflows/agent-fix-pr.yml
+++ b/.github/workflows/agent-fix-pr.yml
@@ -1,0 +1,94 @@
+name: Agent Fix PR
+
+on:
+  pull_request:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to fix.
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: agent-fix-pr-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  openhands-fix:
+    name: Fix-loop agent
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'agent:fix') ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '@agent-fix')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout prompt assets
+        uses: actions/checkout@v4
+
+      - name: Build PR fix prompt
+        id: prompt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          pr_json="$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json title,body,url,headRefName,comments,reviews,statusCheckRollup)"
+          pr_title="$(jq -r .title <<<"$pr_json")"
+          pr_url="$(jq -r .url <<<"$pr_json")"
+          head_ref="$(jq -r .headRefName <<<"$pr_json")"
+
+          cat > /tmp/agent-fix-prompt.md <<'PROMPT'
+          You are the autonomous fix-loop coder agent for kaybarax/todo-list-turborepo.
+
+          Follow AGENTS.md, CLAUDE.md, and .openhands_instructions.
+
+          Your job:
+          1. Inspect the PR, review comments, PR-Agent/Qodo comments, and failing checks.
+          2. Apply the smallest correct fixes to the PR branch.
+          3. Add or update tests if review feedback reveals missing coverage.
+          4. Run the relevant checks.
+          5. Push commits to the PR branch.
+          6. Reply on the PR with what was fixed and what checks were run.
+
+          Constraints:
+          - Use pnpm, never npm or yarn.
+          - Keep changes scoped to review/CI feedback.
+          - Do not merge the PR.
+          - If feedback is wrong or unsafe, explain that in a PR comment instead of making a bad change.
+          PROMPT
+
+          {
+            echo
+            echo "PR: #${PR_NUMBER} - ${pr_title}"
+            echo "URL: ${pr_url}"
+            echo "Head branch: ${head_ref}"
+            echo
+            echo "PR metadata, comments, reviews, and checks:"
+            echo "$pr_json"
+          } >> /tmp/agent-fix-prompt.md
+
+          echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Run OpenHands fix agent
+        uses: All-Hands-AI/openhands-github-action@main
+        with:
+          prompt: /tmp/agent-fix-prompt.md
+          repository: ${{ github.repository }}
+          selected-branch: ${{ steps.prompt.outputs.head_ref }}
+          poll: "true"
+          timeout-seconds: "3600"
+          poll-interval-seconds: "30"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openhands-api-key: ${{ secrets.OPENHANDS_API_KEY }}

--- a/.github/workflows/agent-spec-to-pr.yml
+++ b/.github/workflows/agent-spec-to-pr.yml
@@ -1,0 +1,103 @@
+name: Agent Spec to PR
+
+on:
+  issues:
+    types: [opened, labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number containing the spec to implement.
+        required: true
+      max_iterations:
+        description: Max OpenHands iterations.
+        required: false
+        default: "30"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: agent-spec-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  openhands-implement:
+    name: Coder agent
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.issue.pull_request == null &&
+        contains(github.event.issue.labels.*.name, 'agent:ready') &&
+        contains(github.event.issue.labels.*.name, 'agent:spec')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout prompt assets
+        uses: actions/checkout@v4
+
+      - name: Build implementation prompt
+        id: prompt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          REPOSITORY: ${{ github.repository }}
+          MAX_ITERATIONS: ${{ inputs.max_iterations || '30' }}
+        run: |
+          set -euo pipefail
+          issue_json="$(gh issue view "$ISSUE_NUMBER" --repo "$REPOSITORY" --json title,body,url,labels)"
+          issue_title="$(jq -r .title <<<"$issue_json")"
+          issue_url="$(jq -r .url <<<"$issue_json")"
+          issue_body="$(jq -r .body <<<"$issue_json")"
+
+          cat > /tmp/agent-prompt.md <<'PROMPT'
+          You are the autonomous coder agent for kaybarax/todo-list-turborepo.
+
+          Follow the repository instructions in AGENTS.md, CLAUDE.md, and .openhands_instructions.
+
+          Your job:
+          1. Implement the spec from the GitHub issue below.
+          2. Create or update tests that prove the acceptance criteria.
+          3. Run the narrowest meaningful checks first, then broader checks if the change warrants it.
+          4. Fix all failures you introduced.
+          5. Open a pull request against main.
+          6. In the PR body, include the implemented scope, test commands/results, and any residual risks.
+
+          Constraints:
+          - Use pnpm, never npm or yarn.
+          - Do not change secrets, deployment credentials, or production infrastructure unless explicitly requested.
+          - Keep the PR scoped to the issue.
+          - Do not consider the task complete until the PR exists and is ready for review.
+          - If blocked, open a draft PR with a clear blocker note.
+          PROMPT
+
+          {
+            echo
+            echo "Issue: #${ISSUE_NUMBER} - ${issue_title}"
+            echo "URL: ${issue_url}"
+            echo
+            echo "Spec:"
+            echo "$issue_body"
+          } >> /tmp/agent-prompt.md
+
+      - name: Run OpenHands implementation agent
+        uses: All-Hands-AI/openhands-github-action@main
+        with:
+          prompt: /tmp/agent-prompt.md
+          repository: ${{ github.repository }}
+          selected-branch: main
+          poll: "true"
+          timeout-seconds: "3600"
+          poll-interval-seconds: "30"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openhands-api-key: ${{ secrets.OPENHANDS_API_KEY }}
+
+      - name: Mark issue as handed to agent
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPOSITORY" --body "Agent run completed or stopped. Check the Actions run and any linked PR."

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,58 @@
+name: PR Agent Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize, review_requested]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-agent:
+    name: Review agent
+    if: |
+      github.event.sender.type != 'Bot' &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request != null &&
+          startsWith(github.event.comment.body, '/')
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check AI provider secrets
+        id: provider-secrets
+        env:
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          if [ -n "$OPENAI_KEY" ] || [ -n "$ANTHROPIC_KEY" ] || [ -n "$GEMINI_API_KEY" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "No PR-Agent provider secret configured. Skipping review."
+          fi
+
+      - name: Run PR-Agent
+        if: steps.provider-secrets.outputs.configured == 'true'
+        uses: qodo-ai/pr-agent@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          ANTHROPIC.KEY: ${{ secrets.ANTHROPIC_KEY }}
+          GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "true"
+          github_action_config.auto_improve: "true"
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize", "review_requested"]'

--- a/.openhands_instructions
+++ b/.openhands_instructions
@@ -1,0 +1,28 @@
+# OpenHands Agent Instructions
+
+You are working in `kaybarax/todo-list-turborepo`, an enterprise Turborepo monorepo.
+
+Read and follow `AGENTS.md` and `CLAUDE.md` before changing code.
+
+Core rules:
+- Use `pnpm` only. Never use npm or yarn in this repo.
+- Prefer narrow package/app checks before expensive full-repo checks.
+- Keep changes scoped to the issue or PR feedback.
+- Update or add tests for behavior changes.
+- Do not change production deployment credentials, GitHub secrets, Kubernetes secrets, Terraform state, or environment secrets unless the issue explicitly asks for it.
+- Do not merge PRs. The merge workflow is separate and gated.
+
+Useful checks:
+- General quality: `pnpm lint`, `pnpm typecheck`, `pnpm test`
+- Quick build: `pnpm build:quick`
+- API work: `pnpm build:api`, relevant API tests
+- API Bun work: `pnpm build:api-bun`, `pnpm test:api-bun`
+- Web work: `pnpm build:web`, relevant UI tests
+- Shared services: `pnpm --filter @todo/services test`
+- Contracts: `pnpm contracts:compile`, network-specific contract tests when applicable
+
+Pull request expectations:
+- Explain the spec implemented.
+- List tests/checks run and their results.
+- Mention any risks, skipped checks, or follow-up work.
+- Keep the PR ready for PR-Agent review.

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,27 @@
+[config]
+response_language = "en-US"
+model = "gpt-5.4"
+fallback_models = ["gpt-5.4-mini"]
+
+[pr_reviewer]
+extra_instructions = """\
+Review this Turborepo as a senior engineer.
+
+Focus on:
+- Correctness, security, data integrity, and regressions.
+- Whether the implementation satisfies the linked issue/spec acceptance criteria.
+- Monorepo boundaries: apps should use shared packages instead of duplicating logic.
+- TypeScript type safety and meaningful test coverage.
+- API changes that need docs, OpenAPI updates, migrations, or compatibility notes.
+- Blockchain changes that need contract tests and network-specific validation.
+
+Avoid low-value style comments that are already covered by ESLint, Prettier, or TypeScript.
+"""
+
+[pr_description]
+generate_ai_title = true
+use_description_markers = true
+
+[pr_code_suggestions]
+num_code_suggestions = 6
+suggestions_score_threshold = 7

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1,0 +1,53 @@
+# Autonomous Agent Workflow
+
+This repository is configured for a spec-to-PR agent workflow.
+
+## Required Secrets
+
+Add these repository secrets in GitHub Settings -> Secrets and variables -> Actions:
+
+- `OPENHANDS_API_KEY`: Required for the OpenHands coder/fix agents.
+- `OPENAI_KEY`: Required if PR-Agent uses OpenAI models.
+- `ANTHROPIC_KEY`: Optional, if PR-Agent is configured for Anthropic models.
+- `GEMINI_API_KEY`: Optional, if PR-Agent is configured for Gemini models.
+
+Optional repository variable:
+
+- `AGENT_AUTOMERGE_ENABLED=true`: Enables the guarded auto-merge workflow. Leave unset or false until agent PRs have proven reliable.
+
+## Labels
+
+- `agent:spec`: Identifies an issue as an implementation spec.
+- `agent:ready`: Allows the coder agent to start.
+- `agent:fix`: Re-runs the fix-loop agent on a PR.
+- `agent:auto-merge`: Allows auto-merge when `AGENT_AUTOMERGE_ENABLED=true`.
+- `review-this`: Manually asks review agents to review a PR.
+
+## Spec to PR
+
+1. Create an issue using the "Agent Spec" template.
+2. Fill in the goal, acceptance criteria, scope, and required tests.
+3. Keep or add the `agent:ready` label.
+4. The `Agent Spec to PR` workflow sends the spec to OpenHands.
+5. OpenHands should implement the work, run checks, and open a PR.
+
+You can also trigger manually from Actions -> Agent Spec to PR.
+
+## Review and Fix Loop
+
+1. `PR Agent Review` runs on new/synchronized PRs and comments with findings.
+2. To ask the coder agent to fix comments or CI failures, add the `agent:fix` label to the PR.
+3. Alternatively, comment `@agent-fix` on the PR.
+4. The fix agent inspects comments/checks, pushes fixes, and comments with what changed.
+
+## Merge
+
+Default: humans merge after CI and review.
+
+Optional autonomous merge:
+
+1. Set repository variable `AGENT_AUTOMERGE_ENABLED=true`.
+2. Add `agent:auto-merge` to a PR.
+3. GitHub auto-merge is enabled with squash merge and branch deletion.
+
+Keep auto-merge disabled until the workflow has successfully handled several low-risk specs.


### PR DESCRIPTION
## Summary
- add issue/spec-driven OpenHands implementation workflow
- add PR-Agent review workflow and fix-loop OpenHands workflow
- add guarded auto-merge workflow, disabled by default via AGENT_AUTOMERGE_ENABLED=false
- add repo-specific agent instructions and docs

## Verification
- yq parsed all new workflow/template YAML
- actionlint passed for all new workflows
- created labels: agent:spec, agent:ready, agent:fix, agent:auto-merge, review-this
- set repo variable AGENT_AUTOMERGE_ENABLED=false

## Required follow-up secrets
- OPENHANDS_API_KEY for coder/fix agents
- OPENAI_KEY for PR-Agent default model, or configure .pr_agent.toml/provider secrets for Anthropic/Gemini
