### PR TITLE
agent: 001 gateway api gateway scaffold package

### DIFF
--- a/apps/api-gateway/package.json
+++ b/apps/api-gateway/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@todo/api-gateway",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "bun --watch src/index.ts",
+    "start": "bun src/index.ts",
+    "build": "bun build src/index.ts --target=bun --outdir=dist",
+    "start:prod": "bun dist/index.js",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test test/schemas.test.ts && bun test test/smoke.test.ts",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "openapi:export": "bun scripts/export-openapi.ts",
+    "openapi:compare": "bun scripts/compare-openapi.ts"
+  },
+  "dependencies": {
+    "@elysiajs/bearer": "^1.4.4",
+    "@elysiajs/cors": "^1.4.2",
+    "@elysiajs/jwt": "^1.4.2",
+    "@elysiajs/openapi": "1.4.15",
+    "@sinclair/typebox": "^0.34.49",
+    "bcryptjs": "^3.0.3",
+    "elysia": "^1.4.28",
+    "elysia-helmet": "^3.1.0",
+    "elysia-rate-limit": "^4.6.1",
+    "ioredis": "^5.10.1",
+    "isomorphic-dompurify": "^3.12.0",
+    "mongoose": "^8.17.2"
+  },
+  "devDependencies": {
+    "@todo/config-eslint": "workspace:*",
+    "@todo/config-ts": "workspace:*",
+    "@types/bcrypt": "^5.0.2",
+    "@types/bcryptjs": "^3.0.0",
+    "@types/bun": "latest",
+    "@types/dompurify": "^3.2.0",
+    "eslint": "^9.18.0",
+    "mongodb-memory-server": "^10.2.0",
+    "openapi-diff": "^0.24.1",
+    "typescript": "^5.9.2"
+  }
+}


### PR DESCRIPTION
## Agent Spec

Source spec: `/Users/kevin/workspace/openhandsagent/hermes-agentic-runs/20260510-063721-todo-list-turborepo-gateway-api-gateway-scaffold-package/specs/001-gateway-api-gateway-scaffold-package.md`

## Summary

This PR was created by `workspace-agent` from a markdown spec.

## Spec

# Gateway API Gateway Scaffold Package

## Source

- Repository: `/Users/kevin/workspace/todo-list-turborepo`
- Primary source document: `/Users/kevin/workspace/todo-list-turborepo/docs/api/gateway/13-execution-todo-lists.md`
- Required context directory: `/Users/kevin/workspace/todo-list-turborepo/docs/api/gateway`

Hermes and OpenHands must inspect the required context directory before implementation so the scaffold follows the gateway migration plan and existing local conventions.

## Scope

Implement only these three todo items from Phase 1: Gateway App Scaffold:

- [ ] Create `apps/api-gateway/`.
- [ ] Add `apps/api-gateway/package.json`.
- [ ] Set package name to `@todo/api-gateway`.

## Context From Source

Immediately before Phase 1, the source document records this Phase 0 context:

```markdown
mobile/src/config/api.ts:9` — `const bunUrl = ... || 'http://localhost:3002'` (fallback default, not hardcoded test URL)

### Validation

```bash
pnpm typecheck
pnpm --filter @todo/api-bun test
```

Run broader validation only if the repo is already green enough:

```bash
pnpm quality
```

### Exit Criteria

- Existing APIs are understood and reachable.
- Existing frontend API selection behavior is documented.
- Known baseline failures, if any, are recorded before gateway work begins.

## Phase 1: Gateway App Scaffold

### Objective

Create a runnable `apps/api-gateway` workspace app using Bun + Elysia.

### Dependencies

- Phase 0 complete.
- `apps/api-bun` can be used as the closest local convention.

### Todo

- [ ] Create `apps/api-gateway/`.
- [ ] Add `apps/api-gateway/package.json`.
- [ ] Set package name to `@todo/api-gateway`.
```

## Implementation Guidance

- Use `apps/api-bun` as the closest convention for package metadata, script naming, module type, and dependency style.
- Keep this PR intentionally small. Do not implement the runnable Bun/Elysia server yet unless existing workspace conventions require a minimal file for package validity.
- Do not mark unrelated checklist items complete.
- If checklist progress is updated in `docs/api/gateway/13-execution-todo-lists.md`, update only the three scoped items above.
- Avoid unrelated formatting changes.

## Validation

Run:

```bash
pnpm typecheck
pnpm --filter @todo/api-bun test
```

Run only if the repo appears green enough and the cost is reasonable:

```bash
pnpm quality
```

If any validation fails because of known baseline failures unrelated to this scaffold, record that clearly in the PR summary and task notes.

## Exit Criteria

- `apps/api-gateway/` exists.
- `apps/api-gateway/package.json` exists.
- `apps/api-gateway/package.json` has `"name": "@todo/api-gateway"`.
- The implementation follows nearby workspace conventions from `apps/api-bun`.
- Required validation was run or any inability/failure was documented.

