### PR TITLE
Add API gateway lint and OpenAPI export

### DIFF
--- a/apps/api-gateway/eslint.config.js
+++ b/apps/api-gateway/eslint.config.js
@@ -1,0 +1,32 @@
+const baseConfig = require('@todo/config-eslint/base');
+
+module.exports = [
+  ...baseConfig,
+  {
+    ignores: ['dist/**', 'node_modules/**', 'eslint.config.js'],
+  },
+  {
+    files: ['src/**/*.ts', 'scripts/**/*.ts'],
+    languageOptions: {
+      globals: {
+        Bun: 'readonly',
+        process: 'readonly',
+        console: 'readonly',
+      },
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: __dirname,
+      },
+    },
+    settings: {
+      'import/resolver': {
+        typescript: {
+          alwaysTryTypes: true,
+          project: './tsconfig.json',
+        },
+      },
+      'import/external-module-folders': ['node_modules', 'node_modules/@types'],
+      'import/core-modules': ['bun', 'bun:test', 'bun:jsc', 'bun:sqlite'],
+    },
+  },
+];

--- a/apps/api-gateway/package.json
+++ b/apps/api-gateway/package.json
@@ -8,21 +8,24 @@
     "build": "bun build src/index.ts --target=bun --outdir=dist",
     "start:prod": "bun dist/index.js",
     "typecheck": "tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test",
+    "lint": "eslint \"src/**/*.ts\" \"scripts/**/*.ts\"",
+    "openapi:export": "bun scripts/export-openapi.ts"
   },
   "dependencies": {
-    "elysia": "latest",
-    "@elysiajs/cors": "latest",
     "@elysiajs/bearer": "latest",
+    "@elysiajs/cors": "latest",
     "@elysiajs/jwt": "latest",
+    "@elysiajs/openapi": "1.4.15",
     "@sinclair/typebox": "latest",
+    "elysia": "latest",
     "ioredis": "latest"
   },
   "devDependencies": {
-    "@types/bun": "latest",
-    "typescript": "^5.0.0",
-    "eslint": "latest",
     "@todo/config-eslint": "workspace:*",
-    "@todo/config-ts": "workspace:*"
+    "@todo/config-ts": "workspace:*",
+    "@types/bun": "latest",
+    "eslint": "^9.0.0",
+    "typescript": "^5.0.0"
   }
 }

--- a/apps/api-gateway/scripts/export-openapi.ts
+++ b/apps/api-gateway/scripts/export-openapi.ts
@@ -1,0 +1,26 @@
+import { writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { app } from '../src/app';
+
+async function exportOpenAPI() {
+  console.log('Exporting OpenAPI spec...');
+
+  const response = await app.handle(new Request('http://localhost/api/docs/json'));
+
+  if (!response.ok) {
+    console.error('Failed to fetch OpenAPI spec', await response.text());
+    process.exit(1);
+  }
+
+  const spec = await response.json();
+  const outputPath = resolve(__dirname, '../../../docs/api/openapi/gateway-current.openapi.json');
+
+  writeFileSync(outputPath, `${JSON.stringify(spec, null, 2)}\n`);
+  console.log(`OpenAPI spec exported to: ${outputPath}`);
+}
+
+exportOpenAPI().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/api-gateway/src/__tests__/app.test.ts
+++ b/apps/api-gateway/src/__tests__/app.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+
 import { app } from '../app';
 
 describe('api-gateway', () => {

--- a/apps/api-gateway/src/app.ts
+++ b/apps/api-gateway/src/app.ts
@@ -1,4 +1,23 @@
+import { openapi } from '@elysiajs/openapi';
 import { Elysia } from 'elysia';
+
 import { indexRoute } from './routes/index.route';
 
-export const app = new Elysia().use(indexRoute);
+export const app = new Elysia()
+  .use(
+    openapi({
+      path: '/api/docs',
+      documentation: {
+        info: {
+          title: 'API Gateway',
+          description: 'Unified API Gateway for the Todo application',
+          version: '0.0.1',
+        },
+        tags: [{ name: 'Gateway', description: 'Gateway general endpoints' }],
+      },
+      exclude: {
+        paths: ['/api/docs', '/api/docs/json'],
+      },
+    }),
+  )
+  .use(indexRoute);

--- a/apps/api-gateway/tsconfig.json
+++ b/apps/api-gateway/tsconfig.json
@@ -6,6 +6,6 @@
     "types": ["bun"],
     "strict": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "scripts/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/docs/api/gateway/13-execution-todo-lists.md
+++ b/docs/api/gateway/13-execution-todo-lists.md
@@ -123,19 +123,19 @@ Create a runnable `apps/api-gateway` workspace app using Bun + Elysia.
 - [x] Create `apps/api-gateway/`.
 - [x] Add `apps/api-gateway/package.json`.
 - [x] Set package name to `@todo/api-gateway`.
-- [ ] Add scripts:
+- [x] Add scripts:
   - [x] `dev`
   - [x] `start`
   - [x] `build`
   - [x] `start:prod`
   - [x] `typecheck`
   - [x] `test`
-  - [ ] `lint`
-  - [ ] `openapi:export`
+  - [x] `lint`
+  - [x] `openapi:export`
 - [ ] Add runtime dependencies:
   - [x] `elysia`
   - [x] `@elysiajs/cors`
-  - [ ] `@elysiajs/openapi`
+  - [x] `@elysiajs/openapi`
   - [x] `@elysiajs/bearer`
   - [x] `@elysiajs/jwt`
   - [ ] `elysia-helmet`
@@ -153,7 +153,7 @@ Create a runnable `apps/api-gateway` workspace app using Bun + Elysia.
   - [x] `@todo/config-eslint`
   - [x] `@todo/config-ts`
 - [x] Add `apps/api-gateway/tsconfig.json`.
-- [ ] Add `apps/api-gateway/eslint.config.js`.
+- [x] Add `apps/api-gateway/eslint.config.js`.
 - [x] Add `apps/api-gateway/.env.example`.
 - [x] Add `apps/api-gateway/src/index.ts`.
 - [x] Add `apps/api-gateway/src/app.ts`.

--- a/docs/api/openapi/gateway-current.openapi.json
+++ b/docs/api/openapi/gateway-current.openapi.json
@@ -1,0 +1,24 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API Gateway",
+    "description": "Unified API Gateway for the Todo application",
+    "version": "0.0.1"
+  },
+  "tags": [
+    {
+      "name": "Gateway",
+      "description": "Gateway general endpoints"
+    }
+  ],
+  "paths": {
+    "/api/v1": {
+      "get": {
+        "operationId": "getApiV1"
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,6 +286,9 @@ importers:
       '@elysiajs/jwt':
         specifier: latest
         version: 1.4.2(elysia@1.4.28(@sinclair/typebox@0.34.49)(@types/bun@1.3.14)(exact-mirror@1.0.0)(file-type@21.0.0)(openapi-types@12.1.3)(typescript@5.9.2))
+      '@elysiajs/openapi':
+        specifier: 1.4.15
+        version: 1.4.15(elysia@1.4.28(@sinclair/typebox@0.34.49)(@types/bun@1.3.14)(exact-mirror@1.0.0)(file-type@21.0.0)(openapi-types@12.1.3)(typescript@5.9.2))
       '@sinclair/typebox':
         specifier: latest
         version: 0.34.49
@@ -306,8 +309,8 @@ importers:
         specifier: latest
         version: 1.3.14
       eslint:
-        specifier: latest
-        version: 10.4.0(jiti@2.5.1)
+        specifier: ^9.0.0
+        version: 9.33.0(jiti@2.5.1)
       typescript:
         specifier: ^5.0.0
         version: 5.9.2


### PR DESCRIPTION
## Summary
- add API gateway lint and openapi:export scripts
- wire Elysia OpenAPI docs/export support and commit the generated gateway spec
- update Phase 1 checklist items for lint, openapi:export, OpenAPI dependency, and eslint config

## Validation
- pnpm --filter @todo/api-gateway lint
- pnpm --filter @todo/api-gateway openapi:export
- pnpm --filter @todo/api-gateway typecheck
- pnpm --filter @todo/api-gateway build
- pnpm --filter @todo/api-gateway test

## Review
- HOCA OpenHands review: LGTM
