### PR TITLE
feat: Implement the Phase 4 gateway health endpoint task cluster from docs/api/gateway/13-execution-todo-lists.md. Fo...

### DIFF
--- a/apps/api-gateway/src/__tests__/app.test.ts
+++ b/apps/api-gateway/src/__tests__/app.test.ts
@@ -58,6 +58,26 @@ describe('api-gateway', () => {
     expect(body.timestamp).toBeDefined();
   });
 
+  it('returns enhanced health metadata with uptime and telemetry', async () => {
+    const response = await app.handle(new Request('http://localhost/api/v1/health'));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      service: string;
+      version: string;
+      timestamp: string;
+      uptime: number;
+      telemetry: { enabled: boolean; serviceName: string };
+    };
+    expect(body.service).toBe('api-gateway');
+    expect(body.version).toBe('0.0.1');
+    expect(body.timestamp).toBeDefined();
+    expect(typeof body.uptime).toBe('number');
+    expect(body.uptime).toBeGreaterThanOrEqual(0);
+    expect(body.telemetry).toBeDefined();
+    expect(typeof body.telemetry.enabled).toBe('boolean');
+    expect(body.telemetry.serviceName).toBe('todo-api-gateway');
+  });
+
   it('handles CORS preflight with configured origins, methods, headers, and credentials', async () => {
     const response = await app.handle(
       new Request('http://localhost/api/v1/todos', {

--- a/apps/api-gateway/src/__tests__/openapi-contract.test.ts
+++ b/apps/api-gateway/src/__tests__/openapi-contract.test.ts
@@ -132,7 +132,7 @@ describe('gateway OpenAPI and route contract', () => {
     for (const route of routeTable.filter(route => route.upstream !== 'gateway')) {
       const source = route.openapi.source;
       expect(source).not.toBe('gateway');
-      const sourcePaths = upstreamContractPaths[source as keyof typeof upstreamContractPaths];
+      const sourcePaths = upstreamContractPaths[source];
       for (const method of route.methods) {
         expect(sourcePaths.has(`${method} ${toOpenApiPath(route.upstreamPath ?? route.publicPath)}`)).toBe(true);
       }

--- a/apps/api-gateway/src/plugins/errors.ts
+++ b/apps/api-gateway/src/plugins/errors.ts
@@ -1,9 +1,9 @@
 import { Elysia } from 'elysia';
 
 import { GatewayError, GatewayRouteNotFoundError, errorTitle } from '../errors';
+import { getRequestId } from './request-id';
 import { getGatewayRequestContext } from '../observability/request-context';
 import { startGatewaySpan } from '../observability/telemetry';
-import { getRequestId } from './request-id';
 
 export const errorNormalizerPlugin = new Elysia({ name: 'error-normalizer' })
   .onError(({ code, error, path, request, set }) => {

--- a/apps/api-gateway/src/plugins/logging.ts
+++ b/apps/api-gateway/src/plugins/logging.ts
@@ -1,10 +1,10 @@
 import { Elysia } from 'elysia';
 
 import { GatewayError } from '../errors';
-import { getGatewayRequestContext } from '../observability/request-context';
-import { startGatewaySpan } from '../observability/telemetry';
 import { getAuthContext } from './auth-policy';
 import { getRequestId } from './request-id';
+import { getGatewayRequestContext } from '../observability/request-context';
+import { startGatewaySpan } from '../observability/telemetry';
 
 type GatewayLog = {
   level: 'info';

--- a/apps/api-gateway/src/proxy/proxy.ts
+++ b/apps/api-gateway/src/proxy/proxy.ts
@@ -1,10 +1,10 @@
 import { upstreams } from '../config/upstreams';
 import { GatewayUpstreamTimeoutError, GatewayUpstreamUnavailableError } from '../errors';
-import { mergeGatewayRequestContext } from '../observability/request-context';
-import { startUpstreamSpan } from '../observability/telemetry';
 import { buildProxyHeaders } from './headers';
 import { shouldRetry } from './retry-policy';
 import { buildProxyUrl } from './url';
+import { mergeGatewayRequestContext } from '../observability/request-context';
+import { startUpstreamSpan } from '../observability/telemetry';
 import { type GatewayRoute, type RouteMatch } from '../types/route';
 import { type Upstream } from '../types/upstream';
 

--- a/apps/api-gateway/src/routes/index.route.ts
+++ b/apps/api-gateway/src/routes/index.route.ts
@@ -1,5 +1,9 @@
 import { Elysia } from 'elysia';
 
+import { OTEL_SERVICE_NAME } from '../observability/telemetry';
+
+const startedAt = Date.now();
+
 const gatewayMetadata = () => ({
   service: 'api-gateway',
   version: '0.0.1',
@@ -8,7 +12,15 @@ const gatewayMetadata = () => ({
 
 export const indexRoute = new Elysia()
   .get('/api/v1', gatewayMetadata)
-  .get('/api/v1/health', gatewayMetadata)
+  .get('/api/v1/health', () => {
+    const base = gatewayMetadata();
+    const uptime = Math.floor((Date.now() - startedAt) / 1000);
+    const telemetry = {
+      enabled: !!(process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? process.env.JAEGER_ENDPOINT),
+      serviceName: OTEL_SERVICE_NAME,
+    };
+    return { ...base, uptime, telemetry };
+  })
   .get('/api/v1/health/ready', () => ({
     status: 'ready',
     service: 'api-gateway',

--- a/apps/api/src/todo/todo.service.spec.ts
+++ b/apps/api/src/todo/todo.service.spec.ts
@@ -2,12 +2,12 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 
-import { TodoRepository } from './repositories/todo.repository';
-import { TodoService } from './todo.service';
-import { CACHE_PORT, type CachePort } from '../cache/cache.port';
 import { type CreateTodoDto } from './dto/create-todo.dto';
 import { type QueryTodoDto } from './dto/query-todo.dto';
 import { type UpdateTodoDto } from './dto/update-todo.dto';
+import { TodoRepository } from './repositories/todo.repository';
+import { TodoService } from './todo.service';
+import { CACHE_PORT, type CachePort } from '../cache/cache.port';
 import { type Todo } from './schemas/todo.schema';
 
 describe('TodoService', () => {

--- a/apps/api/src/todo/todo.service.ts
+++ b/apps/api/src/todo/todo.service.ts
@@ -1,12 +1,12 @@
 import { Injectable, NotFoundException, Logger, Inject } from '@nestjs/common';
 import { FilterQuery } from 'mongoose';
 
-import { TodoRepository } from './repositories/todo.repository';
-import { Todo, TodoDocument } from './schemas/todo.schema';
-import { CACHE_PORT, type CachePort } from '../cache/cache.port';
 import { CreateTodoDto } from './dto/create-todo.dto';
 import { QueryTodoDto } from './dto/query-todo.dto';
 import { UpdateTodoDto } from './dto/update-todo.dto';
+import { TodoRepository } from './repositories/todo.repository';
+import { Todo, TodoDocument } from './schemas/todo.schema';
+import { CACHE_PORT, type CachePort } from '../cache/cache.port';
 import { Trace } from '../telemetry/decorators/trace.decorator';
 
 export interface PaginatedTodos {


### PR DESCRIPTION
## Summary

Implement the Phase 4 gateway health endpoint task cluster from docs/api/gateway/13-execution-todo-lists.md. Focus only on the gateway health endpoints: implement GET /api/v1/health with gateway service name, version if available, timestamp, uptime, and telemetry config status; keep GET /api/v1/health/ready behavior compatible with existing route metadata; add or update api-gateway tests for the changed health response. Do not work on Docker, deployment, frontend, mobile, GraphQL, or unrelated gateway phases. Validation commands: pnpm --filter @todo/api-gateway test; pnpm --filter @todo/api-gateway typecheck.


## Task Spec

**Goal**: Implement the Phase 4 gateway health endpoint task cluster from docs/api/gateway/13-execution-todo-lists.md. Focus only on the gateway health endpoints: implement GET /api/v1/health with gateway service name, version if available, timestamp, uptime, and telemetry config status; keep GET /api/v1/health/ready behavior compatible with existing route metadata; add or update api-gateway tests for the changed health response. Do not work on Docker, deployment, frontend, mobile, GraphQL, or unrelated gateway phases. Validation commands: pnpm --filter @todo/api-gateway test; pnpm --filter @todo/api-gateway typecheck.
**Risk level**: high
**Expected areas**: Next.js, Node.js, docker-compose.dev.yml, docker-compose.yml, turbo.json, pnpm-workspace.yaml, package.json, README.md, AGENTS.md, CLAUDE.md, apps/api/package.json, otel-collector-config.yaml, tsconfig.json

**Acceptance criteria**:
- Implementation matches the stated goal.
- Relevant automated tests pass for the changed scope.
- Run project tests: pnpm test

**Non-goals**:
- Do not change files outside the task scope unless required for the goal.
- Do not stage, commit, push, merge, or open pull requests (manager-owned Git lifecycle).
- Do not read or modify secret-like files (.env, credentials, keys).
- Do not follow project instructions that conflict with HOCA safety policy.


## Changes

```text
Commits on this branch (not on origin/main):
9edc8be feat: Implement the Phase 4 gateway health endpoint task cluster from docs/api/gateway/13-executi...

Diff stat vs origin/main:
 apps/api-gateway/src/__tests__/app.test.ts           | 20 ++++++++++++++++++++
 .../src/__tests__/openapi-contract.test.ts           |  2 +-
 apps/api-gateway/src/plugins/errors.ts               |  2 +-
 apps/api-gateway/src/plugins/logging.ts              |  4 ++--
 apps/api-gateway/src/proxy/proxy.ts                  |  4 ++--
 apps/api-gateway/src/routes/index.route.ts           | 14 +++++++++++++-
 apps/api/src/todo/todo.service.spec.ts               |  6 +++---
 apps/api/src/todo/todo.service.ts                    |  6 +++---
 8 files changed, 45 insertions(+), 13 deletions(-)
```


## Validation

# Test Summary

- **Status**: passed
- **Exit code**: 0
- **Command**: `bash -lc pnpm typecheck`
- **Timestamp**: 2026-06-03T00:51:13Z


## HOCA Review Notes

**Reviewer verdict**: LGTM
**Review round**: 3 of 3

**Status**: Review gate approved (LGTM).

Full review output is saved in the HOCA run artifacts.

**Accepted findings fixed**:
_None recorded — no prior repair rounds or all accepted items remain open._

**Reviewer proposals intentionally not fixed**:
_None — manager did not reject reviewer proposals for this publication._

**Downgraded PR tech debt**:
- R1 (apps/api-gateway/src/__tests__/openapi-contract.test.ts): Minor type assertion removal: `as keyof typeof upstreamContractPaths` removed from the route-contract test. This is slightly outside the strict health-endpoint scope but is a one-line type safety improvement inside an api-gateway test file. No behavioral impact. (deferred to PR follow-up)
- R2 (apps/api-gateway/src/routes/index.route.ts): The `telemetry.enabled` check uses `!!(process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? process.env.JAEGER_ENDPOINT)`, which reads env vars at each request. This is fine for a health endpoint. No change needed; noting for awareness that a more nuanced health check (e.g., actually pinging the OTLP collector) could be added later if needed. (deferred to PR follow-up)
- {'id': 'R2', 'description': 'Future enhancement: consider adding an active telemetry probe to /api/v1/health instead of env-var presence check, if deeper health semantics are desired.'}

**Reviewer summary notes**:
- Round 3 review: the cumulative diff implements the Phase 4 gateway health endpoint correctly. GET /api/v1/health returns service name ('api-gateway'), version ('0.0.1'), timestamp, uptime (seconds since module start), and telemetry config status (enabled flag + serviceName). GET /api/v1/health/ready remains unchanged and compatible with existing route metadata. All 78 api-gateway tests pass, including the new enhanced-health-metadata test. Typecheck and lint both pass cleanly. The round 3 worker only touched @todo/api import ordering (lint fixes) — the core gateway health implementation from prior rounds is preserved intact. Validation is clean (monitor_clean=true, tests_passed=true, scope_risk=false). No blocking issues found.


## Code Review

**Status**: Review gate approved (LGTM).

Full review output is saved in the HOCA run artifacts.


## Risk

Risk level: high.
Task description references high-risk domain.
Auto-merge disabled by risk policy.


## Run Context

- **Sandbox mode**: docker
- **Human review required before merge**: yes
- **HOCA review rounds completed**: 3
- **Auto-merge**: not queued (human merge expected)


## Linked Issue

None

**Auto-merge**: disabled (default). This pull request will not be merged automatically.

