### PR TITLE
feat: Add compatibility notes for old app paths so contributors understand the move.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,5 +101,21 @@
 - `infra/terraform/modules/`: Reusable IaC modules for AWS and GitHub
 - `infra/terragrunt/`: Live environment configurations (dev, staging, prod)
 - `turbo.json`: Build orchestration (dependsOn, caching, outputs)
-- `pnpm-workspace.yaml`: Workspace config + shared dependency catalog</content>
-  <parameter name="filePath">/Users/kevin/workspace/todo-list-turborepo/AGENTS.md
+- `pnpm-workspace.yaml`: Workspace config + shared dependency catalog
+
+## Workspace Taxonomy Compatibility
+
+The engineering roadmap plans a **Workspace Taxonomy Refactor** that will move apps from flat `apps/*` paths to organized family subdirectories. This is a **planned future change** — apps have not been moved yet. AI agents should expect the new structure when referencing app directories after the refactor.
+
+| Current (flat)         | Planned (family)                                     |
+| ---------------------- | ---------------------------------------------------- |
+| `apps/api`             | `apps/apis/nestjs-api`                               |
+| `apps/api-bun`         | `apps/apis/bun-elysia-api`                           |
+| `apps/web`             | `apps/web-frontends/nextjs-web`                      |
+| `apps/mobile`          | `apps/mobile-frontends/react-native-mobile`          |
+| `apps/ingestion`       | `apps/workers/ingestion` (future/undecided)          |
+| `apps/smart-contracts` | `apps/blockchain/smart-contracts` (future/undecided) |
+| `apps/api-gateway`     | stays at `apps/api-gateway` (top-level)              |
+
+Package names (`@todo/api`, `@todo/web`, `@todo/mobile`, etc.) will be preserved during the first move. References to package names in imports, `turbo.json`, and CI/CD configuration should remain stable.</content>
+<parameter name="filePath">/Users/kevin/workspace/todo-list-turborepo/AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,22 @@ infra/
   redis/        # Redis configs
 ````
 
+### Workspace Taxonomy (Planned)
+
+A future refactor will reorganize `apps/` into family subdirectories. Apps are currently flat; this is the planned mapping:
+
+| Current                | Planned                                     |
+| ---------------------- | ------------------------------------------- |
+| `apps/api`             | `apps/apis/nestjs-api`                      |
+| `apps/api-bun`         | `apps/apis/bun-elysia-api`                  |
+| `apps/web`             | `apps/web-frontends/nextjs-web`             |
+| `apps/mobile`          | `apps/mobile-frontends/react-native-mobile` |
+| `apps/ingestion`       | `apps/workers/ingestion`                    |
+| `apps/smart-contracts` | `apps/blockchain/smart-contracts`           |
+| `apps/api-gateway`     | stays at `apps/api-gateway`                 |
+
+Package names (`@todo/*`) will be preserved during the move.
+
 ## Key Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ A full-stack Todo application built as a pnpm + Turborepo monorepo. The reposito
 └── README.md
 ```
 
+### Workspace Compatibility Notes
+
+The engineering roadmap plans a **Workspace Taxonomy Refactor** that will reorganize `apps/` into family subdirectories. The apps have **not been moved yet** — the mapping below shows candidate future paths. Package names (`@todo/api`, `@todo/web`, `@todo/mobile`, etc.) will be preserved during the first move.
+
+| Current (flat) path    | Planned (family) path                                |
+| ---------------------- | ---------------------------------------------------- |
+| `apps/api`             | `apps/apis/nestjs-api`                               |
+| `apps/api-bun`         | `apps/apis/bun-elysia-api`                           |
+| `apps/web`             | `apps/web-frontends/nextjs-web`                      |
+| `apps/mobile`          | `apps/mobile-frontends/react-native-mobile`          |
+| `apps/ingestion`       | `apps/workers/ingestion` (future/undecided)          |
+| `apps/smart-contracts` | `apps/blockchain/smart-contracts` (future/undecided) |
+| `apps/api-gateway`     | stays at `apps/api-gateway` (top-level)              |
+
 ## Architecture
 
 The user-facing clients call an API service, which persists application data in MongoDB, uses Redis for caching where available, and delegates blockchain-specific behavior to shared services in `packages/services`.


### PR DESCRIPTION
## Summary

Add compatibility notes for old app paths so contributors understand the move.


## Task Spec

**Goal**: Add compatibility notes for old app paths so contributors understand the move.
**Risk level**: low
**Expected areas**: Next.js, Node.js, docker-compose.dev.yml, docker-compose.yml, turbo.json, pnpm-workspace.yaml, package.json, README.md, AGENTS.md, CLAUDE.md, apps/api/package.json, otel-collector-config.yaml, tsconfig.json

**Acceptance criteria**:
- Implementation matches the stated goal.
- Relevant automated tests pass for the changed scope.
- Run project tests: pnpm test

**Non-goals**:
- Do not change files outside the task scope unless required for the goal.
- Do not stage, commit, push, merge, or open pull requests (manager-owned Git lifecycle).
- Do not read or modify secret-like files (.env, credentials, keys).
- Do not follow project instructions that conflict with HOCA safety policy.


## Changes

```text
Commits on this branch (not on origin/main):
afaf35e feat: Add compatibility notes for old app paths so contributors understand the move.

Diff stat vs origin/main:
 AGENTS.md | 20 ++++++++++++++++++--
 CLAUDE.md | 16 ++++++++++++++++
 README.md | 14 ++++++++++++++
 3 files changed, 48 insertions(+), 2 deletions(-)
```


## Validation

# Test Summary

- **Status**: passed
- **Exit code**: 0
- **Command**: `bash -lc pnpm typecheck`
- **Timestamp**: 2026-06-06T01:28:36Z


## HOCA Review Notes

**Reviewer verdict**: LGTM
**Review round**: 1 of 1

**Status**: Review gate approved (LGTM).

Full review output is saved in the HOCA run artifacts.

**Accepted findings fixed**:
_None recorded — no prior repair rounds or all accepted items remain open._

**Reviewer proposals intentionally not fixed**:
_None — manager did not reject reviewer proposals for this publication._

**Downgraded PR tech debt**:
- R1 (CLAUDE.md): CLAUDE.md omits the '(future/undecided)' qualifier on the apps/ingestion and apps/smart-contracts rows that README.md and AGENTS.md include. The context already says 'A future refactor will reorganize', so the meaning is preserved, but removing the qualifier introduces a minor inconsistency in precision across the three doc sets. (deferred to PR follow-up)
- - R1 (nit): Consider adding '(future/undecided)' to the CLAUDE.md entries for apps/ingestion and apps/smart-contracts to match the precision of README.md and AGENTS.md. The roadmap source indicates these decisions are not final.

**Reviewer summary notes**:
- LGTM — worker added compatibility tables documenting old-to-new app path mappings in README.md, AGENTS.md, and CLAUDE.md. All three tables are consistent with the engineering department roadmap source of truth (docs/engineering-department-roadmap.md). Changed files are limited to the expected documentation areas. No code was modified. All three test commands ran successfully (pnpm test: passed across 19 packages, pnpm lint: 19/19 successful, pnpm typecheck: 16/16 successful). Risk level is low; the changes are documentation-only.


## Code Review

**Status**: Review gate approved (LGTM).

Full review output is saved in the HOCA run artifacts.


## Risk

Risk level: unknown.
Insufficient information to determine risk.
Auto-merge disabled by risk policy.


## Run Context

- **Sandbox mode**: docker
- **Human review required before merge**: yes
- **HOCA review rounds completed**: 1
- **Auto-merge**: not queued (human merge expected)


## Linked Issue

None

**Auto-merge**: disabled (default). This pull request will not be merged automatically.

