### PR TITLE
feat: From docs/engineering-department-roadmap.md P0 Environment And Secrets Contract: update docs/development/enviro...

### DIFF
--- a/docs/development/environment-variables.md
+++ b/docs/development/environment-variables.md
@@ -13,25 +13,48 @@ This document defines the environment variables used across the Todo List Turbor
 | `JWT_SECRET`  | API            | **Yes** | Runtime       | Secrets Manager | All          | Secret key for signing JWT tokens                      |
 | `LOG_LEVEL`   | All            | No      | Runtime       | Environment     | All          | Logging verbosity (debug, info, warn, error)           |
 
+## Gateway-First Convention
+
+Frontend applications (Web and Mobile) communicate with backend services exclusively through the **API Gateway** (`apps/api-gateway`). The gateway origin is set at build time via the `*_API_GATEWAY_URL` and `*_WS_GATEWAY_URL` variables. Frontends derive their REST, WebSocket, and GraphQL endpoints from these gateway URLs:
+
+- **REST endpoints**: `{API_GATEWAY_URL}/api/v1/...`
+- **GraphQL endpoint**: `{API_GATEWAY_URL}/graphql` (mobile only)
+- **WebSocket connections**: `{WS_GATEWAY_URL}/...`
+
+This gateway-first architecture decouples clients from backend service topology and enables centralized routing, rate limiting, and observability at a single ingress point.
+
+### Migration Note
+
+The project previously used flat `*_API_URL` and `*_WS_URL` variables. These have been superseded by the gateway-first naming convention:
+
+| Legacy (deprecated)   | Canonical (gateway-first)     |
+| --------------------- | ----------------------------- |
+| `NEXT_PUBLIC_API_URL` | `NEXT_PUBLIC_API_GATEWAY_URL` |
+| `NEXT_PUBLIC_WS_URL`  | `NEXT_PUBLIC_WS_GATEWAY_URL`  |
+| `EXPO_PUBLIC_API_URL` | `EXPO_PUBLIC_API_GATEWAY_URL` |
+| `EXPO_PUBLIC_WS_URL`  | `EXPO_PUBLIC_WS_GATEWAY_URL`  |
+
+The legacy `_API_URL` / `_WS_URL` variables are **deprecated** and kept only for backward compatibility during the migration period. New deployments, CI/CD pipelines, and documentation should reference the canonical `*_GATEWAY_*` variants. The deprecated aliases will be removed in a future release.
+
 ## Web Application (`apps/web`)
 
 These variables are prefixed with `NEXT_PUBLIC_` to be exposed to the browser.
 
-| Variable Name                             | Secret | Build/Runtime | Source of Truth  | Description                          |
-| ----------------------------------------- | ------ | ------------- | ---------------- | ------------------------------------ |
-| `NEXT_PUBLIC_API_GATEWAY_URL`             | No     | Build         | Terraform Output | Gateway origin for web REST calls    |
-| `NEXT_PUBLIC_API_URL`                     | No     | Build         | Terraform Output | Compatibility alias for gateway URL  |
-| `NEXT_PUBLIC_WS_GATEWAY_URL`              | No     | Build         | Terraform Output | Gateway WebSocket URL                |
-| `NEXT_PUBLIC_WS_URL`                      | No     | Build         | Terraform Output | Compatibility alias for gateway WS   |
-| `NEXT_PUBLIC_POLYGON_RPC_URL`             | No     | Build         | Environment      | RPC endpoint for Polygon             |
-| `NEXT_PUBLIC_SOLANA_RPC_URL`              | No     | Build         | Environment      | RPC endpoint for Solana              |
-| `NEXT_PUBLIC_POLKADOT_RPC_URL`            | No     | Build         | Environment      | RPC endpoint for Polkadot            |
-| `NEXT_PUBLIC_MOONBEAM_RPC_URL`            | No     | Build         | Environment      | RPC endpoint for Moonbeam            |
-| `NEXT_PUBLIC_BASE_RPC_URL`                | No     | Build         | Environment      | RPC endpoint for Base                |
-| `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID`    | No     | Build         | WalletConnect    | Project ID for WalletConnect v2      |
-| `NEXT_PUBLIC_ENABLE_BLOCKCHAIN`           | No     | Build         | Environment      | Feature flag for blockchain features |
-| `NEXT_PUBLIC_ENABLE_PWA`                  | No     | Build         | Build            | Feature flag for PWA support         |
-| `NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT` | No     | Build         | Terraform Output | OTLP endpoint for tracing            |
+| Variable Name                             | Secret | Build/Runtime | Source of Truth  | Description                                         |
+| ----------------------------------------- | ------ | ------------- | ---------------- | --------------------------------------------------- |
+| `NEXT_PUBLIC_API_GATEWAY_URL`             | No     | Build         | Terraform Output | Gateway origin for web REST calls                   |
+| `NEXT_PUBLIC_API_URL`                     | No     | Build         | Terraform Output | ⚠️ Deprecated — compatibility alias for gateway URL |
+| `NEXT_PUBLIC_WS_GATEWAY_URL`              | No     | Build         | Terraform Output | Gateway WebSocket URL                               |
+| `NEXT_PUBLIC_WS_URL`                      | No     | Build         | Terraform Output | ⚠️ Deprecated — compatibility alias for gateway WS  |
+| `NEXT_PUBLIC_POLYGON_RPC_URL`             | No     | Build         | Environment      | RPC endpoint for Polygon                            |
+| `NEXT_PUBLIC_SOLANA_RPC_URL`              | No     | Build         | Environment      | RPC endpoint for Solana                             |
+| `NEXT_PUBLIC_POLKADOT_RPC_URL`            | No     | Build         | Environment      | RPC endpoint for Polkadot                           |
+| `NEXT_PUBLIC_MOONBEAM_RPC_URL`            | No     | Build         | Environment      | RPC endpoint for Moonbeam                           |
+| `NEXT_PUBLIC_BASE_RPC_URL`                | No     | Build         | Environment      | RPC endpoint for Base                               |
+| `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID`    | No     | Build         | WalletConnect    | Project ID for WalletConnect v2                     |
+| `NEXT_PUBLIC_ENABLE_BLOCKCHAIN`           | No     | Build         | Environment      | Feature flag for blockchain features                |
+| `NEXT_PUBLIC_ENABLE_PWA`                  | No     | Build         | Build            | Feature flag for PWA support                        |
+| `NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT` | No     | Build         | Terraform Output | OTLP endpoint for tracing                           |
 
 ## NestJS API (`apps/api`)
 
@@ -78,20 +101,20 @@ These variables are prefixed with `NEXT_PUBLIC_` to be exposed to the browser.
 
 These variables are prefixed with `EXPO_PUBLIC_` to be available in the React Native bundle.
 
-| Variable Name                          | Secret | Build/Runtime | Source of Truth  | Description                          |
-| -------------------------------------- | ------ | ------------- | ---------------- | ------------------------------------ |
-| `EXPO_PUBLIC_API_GATEWAY_URL`          | No     | Build         | Terraform Output | Gateway origin for mobile calls      |
-| `EXPO_PUBLIC_GRAPHQL_GATEWAY_URL`      | No     | Build         | Terraform Output | Optional GraphQL override for mobile |
-| `EXPO_PUBLIC_API_URL`                  | No     | Build         | Terraform Output | Compatibility alias for gateway URL  |
-| `EXPO_PUBLIC_WS_GATEWAY_URL`           | No     | Build         | Terraform Output | Gateway WebSocket URL                |
-| `EXPO_PUBLIC_WS_URL`                   | No     | Build         | Terraform Output | Compatibility alias for gateway WS   |
-| `EXPO_PUBLIC_POLYGON_RPC_URL`          | No     | Build         | Environment      | RPC endpoint for Polygon             |
-| `EXPO_PUBLIC_SOLANA_RPC_URL`           | No     | Build         | Environment      | RPC endpoint for Solana              |
-| `EXPO_PUBLIC_POLKADOT_RPC_URL`         | No     | Build         | Environment      | RPC endpoint for Polkadot            |
-| `EXPO_PUBLIC_MOONBEAM_RPC_URL`         | No     | Build         | Environment      | RPC endpoint for Moonbeam            |
-| `EXPO_PUBLIC_BASE_RPC_URL`             | No     | Build         | Environment      | RPC endpoint for Base                |
-| `EXPO_PUBLIC_WALLETCONNECT_PROJECT_ID` | No     | Build         | WalletConnect    | Project ID for WalletConnect v2      |
-| `EXPO_PUBLIC_ENABLE_BLOCKCHAIN`        | No     | Build         | Environment      | Feature flag for blockchain features |
+| Variable Name                          | Secret | Build/Runtime | Source of Truth  | Description                                                                    |
+| -------------------------------------- | ------ | ------------- | ---------------- | ------------------------------------------------------------------------------ |
+| `EXPO_PUBLIC_API_GATEWAY_URL`          | No     | Build         | Terraform Output | Gateway origin for mobile calls                                                |
+| `EXPO_PUBLIC_GRAPHQL_GATEWAY_URL`      | No     | Build         | Terraform Output | Optional GraphQL override for mobile (defaults to `{API_GATEWAY_URL}/graphql`) |
+| `EXPO_PUBLIC_API_URL`                  | No     | Build         | Terraform Output | ⚠️ Deprecated — compatibility alias for gateway URL                            |
+| `EXPO_PUBLIC_WS_GATEWAY_URL`           | No     | Build         | Terraform Output | Gateway WebSocket URL                                                          |
+| `EXPO_PUBLIC_WS_URL`                   | No     | Build         | Terraform Output | ⚠️ Deprecated — compatibility alias for gateway WS                             |
+| `EXPO_PUBLIC_POLYGON_RPC_URL`          | No     | Build         | Environment      | RPC endpoint for Polygon                                                       |
+| `EXPO_PUBLIC_SOLANA_RPC_URL`           | No     | Build         | Environment      | RPC endpoint for Solana                                                        |
+| `EXPO_PUBLIC_POLKADOT_RPC_URL`         | No     | Build         | Environment      | RPC endpoint for Polkadot                                                      |
+| `EXPO_PUBLIC_MOONBEAM_RPC_URL`         | No     | Build         | Environment      | RPC endpoint for Moonbeam                                                      |
+| `EXPO_PUBLIC_BASE_RPC_URL`             | No     | Build         | Environment      | RPC endpoint for Base                                                          |
+| `EXPO_PUBLIC_WALLETCONNECT_PROJECT_ID` | No     | Build         | WalletConnect    | Project ID for WalletConnect v2                                                |
+| `EXPO_PUBLIC_ENABLE_BLOCKCHAIN`        | No     | Build         | Environment      | Feature flag for blockchain features                                           |
 
 ## Smart Contracts (`apps/smart-contracts`)
 


### PR DESCRIPTION
## Summary

From docs/engineering-department-roadmap.md P0 Environment And Secrets Contract: update docs/development/environment-variables.md for gateway-first naming, covering NEXT_PUBLIC_API_GATEWAY_URL, NEXT_PUBLIC_WS_GATEWAY_URL, EXPO_PUBLIC_API_GATEWAY_URL, EXPO_PUBLIC_WS_GATEWAY_URL, optional EXPO_PUBLIC_GRAPHQL_GATEWAY_URL, and gateway runtime variables. Keep scope to documentation, run a relevant lightweight validation, and open a PR when complete.


## Task Spec

**Goal**: From docs/engineering-department-roadmap.md P0 Environment And Secrets Contract: update docs/development/environment-variables.md for gateway-first naming, covering NEXT_PUBLIC_API_GATEWAY_URL, NEXT_PUBLIC_WS_GATEWAY_URL, EXPO_PUBLIC_API_GATEWAY_URL, EXPO_PUBLIC_WS_GATEWAY_URL, optional EXPO_PUBLIC_GRAPHQL_GATEWAY_URL, and gateway runtime variables. Keep scope to documentation, run a relevant lightweight validation, and open a PR when complete.
**Risk level**: high
**Expected areas**: docs/engineering-department-roadmap.md, docs/development/environment-variables.md, Next.js, Node.js, docker-compose.dev.yml, docker-compose.yml, turbo.json, pnpm-workspace.yaml, package.json, README.md, AGENTS.md, CLAUDE.md, apps/api/package.json, otel-collector-config.yaml, tsconfig.json

**Acceptance criteria**:
- Implementation matches the stated goal.
- Relevant automated tests pass for the changed scope.
- Run project tests: pnpm test

**Non-goals**:
- Do not change files outside the task scope unless required for the goal.
- Do not stage, commit, push, merge, or open pull requests (manager-owned Git lifecycle).
- Do not read or modify secret-like files (.env, credentials, keys).
- Do not follow project instructions that conflict with HOCA safety policy.


## Changes

```text
Commits on this branch (not on origin/main):
c2f3f6c feat: From docs/engineering-department-roadmap.md P0 Environment And Secrets Contract: update doc...

Diff stat vs origin/main:
 docs/development/environment-variables.md | 81 ++++++++++++++++++++-----------
 1 file changed, 52 insertions(+), 29 deletions(-)
```


## Validation

# Test Summary

- **Status**: passed
- **Exit code**: 0
- **Command**: `bash -lc pnpm typecheck`
- **Timestamp**: 2026-06-06T19:01:13Z


## HOCA Review Notes

**Reviewer verdict**: LGTM
**Review round**: 2 of 2

**Status**: Review gate approved (LGTM).

Full review output is saved in the HOCA run artifacts.

**Accepted findings fixed**:
_None recorded — no prior repair rounds or all accepted items remain open._

**Reviewer proposals intentionally not fixed**:
_None — manager did not reject reviewer proposals for this publication._

**Downgraded PR tech debt**:
_None — no findings were downgraded to PR follow-up._

**Reviewer summary notes**:
- Documentation-only update to docs/development/environment-variables.md adding Gateway-First Convention section, Migration Note with legacy-to-canonical variable mapping, and deprecation annotations on legacy alias rows in the Web and Mobile tables. The change covers all required variables (NEXT_PUBLIC_API_GATEWAY_URL, NEXT_PUBLIC_WS_GATEWAY_URL, EXPO_PUBLIC_API_GATEWAY_URL, EXPO_PUBLIC_WS_GATEWAY_URL, optional EXPO_PUBLIC_GRAPHQL_GATEWAY_URL) and the gateway runtime variables section (apps/api-gateway) already existed in the pre-change document. Scope is confined to one file in expected_areas. No code changes, no security concerns, no scope creep. Validation history: round 1 validation failed due to a stale turbo cache in @todo/api (NestJS test artifacts from a prior branch state). Round 2 worker correctly diagnosed the stale cache and confirmed with `pnpm test --force` that 19/19 tasks pass with 0 failures. After the forced run, the cache was refreshed and subsequent `pnpm test` (no flags) also passes (FULL TURBO, 19/19). Validation round 2 passed (exit_code 0, tests_passed true). The stale cache is a one-time turbo caching issue that will not recur on a clean CI build. Risk level: documented as 'high' in task spec, but this is a markdown-only documentation change with no runtime impact. The change is structurally sound — clear section hierarchy, consistent table formatting, explicit deprecation markers. No structural quality concerns (markdown edit, no code paths, no abstraction, no maintainability regression). No blocking findings. Verdict: LGTM.


## Code Review

**Status**: Review gate approved (LGTM).

Full review output is saved in the HOCA run artifacts.


## Risk

Risk level: high.
Task description references high-risk domain.
Auto-merge disabled by risk policy.


## Run Context

- **Sandbox mode**: docker
- **Human review required before merge**: yes
- **HOCA review rounds completed**: 2
- **Auto-merge**: not queued (human merge expected)


## Linked Issue

None

**Auto-merge**: disabled (default). This pull request will not be merged automatically.

