### PR TITLE
HEPA validation: Implement health tests for all-up, partial-down, and all-down states

### DIFF
--- a/apps/api-bun/test/modules/health/health.test.ts
+++ b/apps/api-bun/test/modules/health/health.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
+import { describe, expect, it, beforeAll, afterAll, spyOn } from 'bun:test';
 
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
@@ -8,49 +8,178 @@ import { cache } from '../../../src/cache';
 import { type HealthResponse, type ReadinessResponse } from '../../../src/schemas/health';
 
 describe('Health Module', () => {
-  let mongod: MongoMemoryServer;
+  // ── All-up state: DB + Cache both connected ──────────────────────────────
+  describe('all-up state (DB + Cache connected)', () => {
+    let mongod: MongoMemoryServer;
 
-  beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    await mongoose.connect(mongod.getUri());
-    await cache.initialize();
-  });
+    beforeAll(async () => {
+      mongod = await MongoMemoryServer.create();
+      await mongoose.connect(mongod.getUri());
+      await cache.initialize();
+    });
 
-  afterAll(async () => {
-    await cache.quit();
-    await mongoose.disconnect();
-    await mongod.stop();
-  });
+    afterAll(async () => {
+      await cache.quit();
+      await mongoose.disconnect();
+      await mongod.stop();
+    });
 
-  describe('GET /api/v1/health', () => {
-    it('should return 200 with health information', async () => {
-      const response = await app.handle(new Request('http://localhost/api/v1/health'));
+    describe('GET /api/v1/health', () => {
+      it('should return 200 with both dependencies reported connected', async () => {
+        const response = await app.handle(new Request('http://localhost/api/v1/health'));
 
-      expect(response.status).toBe(200);
-      const data = (await response.json()) as HealthResponse;
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as HealthResponse;
 
-      expect(data.status).toBe('ok');
-      expect(data.timestamp).toBeDefined();
-      expect(data.uptime).toBeGreaterThan(0);
-      expect(data.database.status).toBe('connected');
-      expect(data.cache.status).toBe('connected');
-      expect(data.memory).toBeDefined();
-      expect(data.version).toBeDefined();
-      expect(data.telemetry).toBeDefined();
+        expect(data.status).toBe('ok');
+        expect(data.timestamp).toBeDefined();
+        expect(data.uptime).toBeGreaterThan(0);
+        expect(data.database.status).toBe('connected');
+        expect(data.cache.status).toBe('connected');
+        expect(data.memory).toBeDefined();
+        expect(data.version).toBeDefined();
+        expect(data.telemetry).toBeDefined();
+      });
+    });
+
+    describe('GET /api/v1/health/ready', () => {
+      it('should return ready when both dependencies are connected', async () => {
+        const response = await app.handle(new Request('http://localhost/api/v1/health/ready'));
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as ReadinessResponse;
+
+        expect(data.status).toBe('ready');
+        expect(data.timestamp).toBeDefined();
+        expect(data.checks.database).toBe(true);
+        expect(data.checks.cache).toBe(true);
+      });
     });
   });
 
-  describe('GET /api/v1/health/ready', () => {
-    it('should return 200 with readiness information', async () => {
-      const response = await app.handle(new Request('http://localhost/api/v1/health/ready'));
+  // ── Partial-down state: DB disconnected, Cache connected ─────────────────
+  describe('partial-down state (DB disconnected, Cache connected)', () => {
+    beforeAll(async () => {
+      // Only initialise cache – do NOT connect to MongoDB
+      await cache.initialize();
+    });
 
-      expect(response.status).toBe(200);
-      const data = (await response.json()) as ReadinessResponse;
+    afterAll(async () => {
+      await cache.quit();
+    });
 
-      expect(data.status).toBe('ready');
-      expect(data.timestamp).toBeDefined();
-      expect(data.checks.database).toBe(true);
-      expect(data.checks.cache).toBe(true);
+    describe('GET /api/v1/health', () => {
+      it('should return 200 with database reported disconnected', async () => {
+        const response = await app.handle(new Request('http://localhost/api/v1/health'));
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as HealthResponse;
+
+        expect(data.status).toBe('ok');
+        expect(data.database.status).toBe('disconnected');
+        expect(data.database.name).toBeDefined();
+        expect(data.cache.status).toBe('connected');
+      });
+    });
+
+    describe('GET /api/v1/health/ready', () => {
+      it('should return not ready when database is disconnected', async () => {
+        const response = await app.handle(new Request('http://localhost/api/v1/health/ready'));
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as ReadinessResponse;
+
+        expect(data.status).toBe('not ready');
+        expect(data.checks.database).toBe(false);
+        expect(data.checks.cache).toBe(true);
+      });
+    });
+  });
+
+  // ── Partial-down state: DB connected, Cache disconnected ─────────────────
+  describe('partial-down state (DB connected, Cache disconnected)', () => {
+    let mongod: MongoMemoryServer;
+    let cachePingSpy: ReturnType<typeof spyOn>;
+
+    beforeAll(async () => {
+      mongod = await MongoMemoryServer.create();
+      await mongoose.connect(mongod.getUri());
+      // Do NOT initialise real cache; stub ping() to simulate disconnect
+      cachePingSpy = spyOn(cache, 'ping').mockImplementation(async () => false);
+    });
+
+    afterAll(async () => {
+      cachePingSpy.mockRestore();
+      await mongoose.disconnect();
+      await mongod.stop();
+    });
+
+    describe('GET /api/v1/health', () => {
+      it('should return 200 with cache reported disconnected', async () => {
+        const response = await app.handle(new Request('http://localhost/api/v1/health'));
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as HealthResponse;
+
+        expect(data.status).toBe('ok');
+        expect(data.database.status).toBe('connected');
+        expect(data.cache.status).toBe('disconnected');
+      });
+    });
+
+    describe('GET /api/v1/health/ready', () => {
+      it('should return not ready when cache is disconnected', async () => {
+        const response = await app.handle(new Request('http://localhost/api/v1/health/ready'));
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as ReadinessResponse;
+
+        expect(data.status).toBe('not ready');
+        expect(data.checks.database).toBe(true);
+        expect(data.checks.cache).toBe(false);
+      });
+    });
+  });
+
+  // ── All-down state: DB + Cache both disconnected ─────────────────────────
+  describe('all-down state (DB disconnected, Cache disconnected)', () => {
+    let cachePingSpy: ReturnType<typeof spyOn>;
+
+    beforeAll(async () => {
+      // Do NOT connect to MongoDB and do NOT initialise cache
+      // Stub cache.ping() to simulate disconnect
+      cachePingSpy = spyOn(cache, 'ping').mockImplementation(async () => false);
+    });
+
+    afterAll(async () => {
+      cachePingSpy.mockRestore();
+    });
+
+    describe('GET /api/v1/health', () => {
+      it('should return 200 with both dependencies reported disconnected', async () => {
+        const response = await app.handle(new Request('http://localhost/api/v1/health'));
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as HealthResponse;
+
+        expect(data.status).toBe('ok');
+        expect(data.database.status).toBe('disconnected');
+        expect(data.database.name).toBeDefined();
+        expect(data.cache.status).toBe('disconnected');
+      });
+    });
+
+    describe('GET /api/v1/health/ready', () => {
+      it('should return not ready when both dependencies are disconnected', async () => {
+        const response = await app.handle(new Request('http://localhost/api/v1/health/ready'));
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as ReadinessResponse;
+
+        expect(data.status).toBe('not ready');
+        expect(data.checks.database).toBe(false);
+        expect(data.checks.cache).toBe(false);
+      });
     });
   });
 });

--- a/apps/api/src/health/health.service.spec.ts
+++ b/apps/api/src/health/health.service.spec.ts
@@ -1,0 +1,197 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getConnectionToken } from '@nestjs/mongoose';
+
+import { HealthService } from './health.service';
+
+describe('HealthService', () => {
+  let service: HealthService;
+
+  const buildMockConnection = (readyState: number, name = 'test-db') =>
+    ({ readyState, name }) as any;
+
+  const buildMockRedisClient = (pingBehavior: 'connected' | 'disconnected' | 'none') => {
+    if (pingBehavior === 'none') return undefined;
+    if (pingBehavior === 'connected') {
+      return { ping: jest.fn().mockResolvedValue('PONG') };
+    }
+    return { ping: jest.fn().mockRejectedValue(new Error('Redis connection refused')) };
+  };
+
+  const compileService = async (
+    readyState: number,
+    redisBehavior: 'connected' | 'disconnected' | 'none',
+  ) => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HealthService,
+        { provide: getConnectionToken(), useValue: buildMockConnection(readyState) },
+        { provide: 'REDIS_CLIENT', useValue: buildMockRedisClient(redisBehavior) },
+      ],
+    }).compile();
+    return module.get<HealthService>(HealthService);
+  };
+
+  // ── All-up state ──────────────────────────────────────────────────────────
+  describe('all-up state (DB + Cache connected)', () => {
+    beforeAll(async () => {
+      service = await compileService(1, 'connected');
+    });
+
+    describe('getHealth', () => {
+      it('should report both dependencies as connected', async () => {
+        const result = await service.getHealth();
+
+        expect(result.status).toBe('ok');
+        expect(result.database.status).toBe('connected');
+        expect(result.cache.status).toBe('connected');
+        expect(result.database.name).toBe('test-db');
+        expect(result.timestamp).toBeDefined();
+        expect(result.uptime).toBeGreaterThan(0);
+        expect(result.memory).toBeDefined();
+        expect(result.version).toBeDefined();
+      });
+    });
+
+    describe('getReadiness', () => {
+      it('should return ready when both dependencies are connected', async () => {
+        const result = await service.getReadiness();
+
+        expect(result.status).toBe('ready');
+        expect(result.checks.database).toBe(true);
+        expect(result.checks.cache).toBe(true);
+      });
+    });
+  });
+
+  // ── Partial-down: DB disconnected, Cache connected ────────────────────────
+  describe('partial-down state (DB disconnected, Cache connected)', () => {
+    beforeAll(async () => {
+      service = await compileService(0, 'connected');
+    });
+
+    describe('getHealth', () => {
+      it('should report database as disconnected', async () => {
+        const result = await service.getHealth();
+
+        expect(result.status).toBe('ok');
+        expect(result.database.status).toBe('disconnected');
+        expect(result.cache.status).toBe('connected');
+      });
+    });
+
+    describe('getReadiness', () => {
+      it('should return not ready when database is disconnected', async () => {
+        const result = await service.getReadiness();
+
+        expect(result.status).toBe('not ready');
+        expect(result.checks.database).toBe(false);
+        expect(result.checks.cache).toBe(true);
+      });
+    });
+  });
+
+  // ── Partial-down: DB connected, Cache disconnected ────────────────────────
+  describe('partial-down state (DB connected, Cache disconnected)', () => {
+    beforeAll(async () => {
+      service = await compileService(1, 'disconnected');
+    });
+
+    describe('getHealth', () => {
+      it('should report cache as disconnected', async () => {
+        const result = await service.getHealth();
+
+        expect(result.status).toBe('ok');
+        expect(result.database.status).toBe('connected');
+        expect(result.cache.status).toBe('disconnected');
+      });
+    });
+
+    describe('getReadiness', () => {
+      it('should return not ready when cache is disconnected', async () => {
+        const result = await service.getReadiness();
+
+        expect(result.status).toBe('not ready');
+        expect(result.checks.database).toBe(true);
+        expect(result.checks.cache).toBe(false);
+      });
+    });
+  });
+
+  // ── All-down: DB + Cache both disconnected ────────────────────────────────
+  describe('all-down state (DB disconnected, Cache disconnected)', () => {
+    beforeAll(async () => {
+      service = await compileService(0, 'disconnected');
+    });
+
+    describe('getHealth', () => {
+      it('should report both dependencies as disconnected', async () => {
+        const result = await service.getHealth();
+
+        expect(result.status).toBe('ok');
+        expect(result.database.status).toBe('disconnected');
+        expect(result.cache.status).toBe('disconnected');
+      });
+    });
+
+    describe('getReadiness', () => {
+      it('should return not ready when both dependencies are disconnected', async () => {
+        const result = await service.getReadiness();
+
+        expect(result.status).toBe('not ready');
+        expect(result.checks.database).toBe(false);
+        expect(result.checks.cache).toBe(false);
+      });
+    });
+  });
+
+  // ── Edge case: Redis client is undefined ──────────────────────────────────
+  describe('edge case: no Redis client configured', () => {
+    beforeAll(async () => {
+      service = await compileService(1, 'none');
+    });
+
+    describe('getHealth', () => {
+      it('should report cache as disconnected when no Redis client is available', async () => {
+        const result = await service.getHealth();
+
+        expect(result.status).toBe('ok');
+        expect(result.database.status).toBe('connected');
+        expect(result.cache.status).toBe('disconnected');
+      });
+    });
+
+    describe('getReadiness', () => {
+      it('should report cache check as false when no Redis client is available', async () => {
+        const result = await service.getReadiness();
+
+        expect(result.status).toBe('not ready');
+        expect(result.checks.database).toBe(true);
+        expect(result.checks.cache).toBe(false);
+      });
+    });
+  });
+
+  // ── Response shape ────────────────────────────────────────────────────────
+  describe('response shape', () => {
+    beforeAll(async () => {
+      service = await compileService(1, 'connected');
+    });
+
+    it('should return a valid ISO timestamp in getHealth', async () => {
+      const result = await service.getHealth();
+      expect(() => new Date(result.timestamp)).not.toThrow();
+      expect(new Date(result.timestamp).toISOString()).toBe(result.timestamp);
+    });
+
+    it('should return a valid ISO timestamp in getReadiness', async () => {
+      const result = await service.getReadiness();
+      expect(() => new Date(result.timestamp)).not.toThrow();
+      expect(new Date(result.timestamp).toISOString()).toBe(result.timestamp);
+    });
+
+    it('should return a positive uptime value', async () => {
+      const result = await service.getHealth();
+      expect(result.uptime).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Fallback Evidence Artifact
- This body is HEPA's deterministic headless/degraded fallback evidence artifact, not Hermes-authored project PR intent.
- In Hermes-present release runs, `hepa-manager` must author `HepaHermesPrIntent` for project-specific PR content.

## Summary
- Status: completed
- Task: Implement health tests for all-up, partial-down, and all-down states
- Expected areas: <task-relevant-files>
- Acceptance criteria:
  - Live worker changes only task-relevant files.
  - Manager-owned validation passes.
  - Manager-owned staging, commit, and pull request creation execute.
- Live worker changed 2 file(s).
- Changed files: apps/api-bun/test/modules/health/health.test.ts, apps/api/src/health/health.service.spec.ts.
- Validation passed for 1 command(s).
- Review fanout passed with 2 reviewer signal(s) and arbitration status residual_accepted.
- Manager staged 2 file(s) and committed 49c3fde1893e3e237dbb4ad5be36e2ef11fad9aa.

## Validation
- Result: passed
- `git diff --check` exited 0

## Review
- review-policy via `hepa-reviewer:fallback-policy:pi`: approved (2 finding(s))
  - rs3-manager-reject-advisory [medium] Policy reviewer advisory for task t_4ee0a725. (accepted=true)
  - rs3-downgrade-out-of-scope [high] Policy reviewer emitted an out-of-scope advisory. (accepted=true)
- review-primary via `hepa-reviewer:fallback-primary:pi`: approved (1 finding(s))
  - rs3-manager-accept-low [low] Primary reviewer found the task t_4ee0a725 diff reviewable. (accepted=true)

## Risk
- Declared risk: low
- Human attention required: false
- Arbitration: residual_accepted
  - rs3-downgrade-out-of-scope: downgraded, High -> Low, accepted=false, reason=Out-of-scope non-release-risk findings are downgraded to low severity and excluded from repair.
  - rs3-manager-accept-low: manager_accepted, Low -> Low, accepted=true, reason=Manager accepts this low-risk review observation after validation passed.
  - rs3-manager-reject-advisory: manager_rejected, Medium -> Medium, accepted=false, reason=Manager rejects the advisory because validation and diff scope are sufficient.

## Adapter
- Lane adapter: pi
- worker adapter: pi
- reviewer adapter: hepa-reviewer:fallback-fanout:pi
- manager adapter: hepa-manager-arbitration
- Sandbox posture: host-worktree

## Timing
- Wall time: 107.39s across 5 phase(s)
- Agent loops: 1 | manager passes: 1 | reviewer passes: 2
- Worker-profile calls: 0 | installs: 0 | containers: 0

## Hermes card
- No Hermes card linked.
