### PR TITLE
Implement aggregated gateway readiness checks with direct validation

### DIFF
--- a/apps/api-gateway/src/__tests__/health.test.ts
+++ b/apps/api-gateway/src/__tests__/health.test.ts
@@ -1,0 +1,173 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+type AppModule = typeof import('../app');
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+type RateLimitModule = typeof import('../plugins/rate-limit');
+
+let app: AppModule['app'];
+let resetRateLimitBuckets: RateLimitModule['resetRateLimitBuckets'];
+
+const originalFetch = globalThis.fetch;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'test-secret-value';
+  process.env.CORS_ORIGIN = 'http://localhost:3000';
+  process.env.RATE_LIMIT_ENABLED = 'true';
+
+  const appModule = await import('../app');
+  const rateLimitModule = await import('../plugins/rate-limit');
+  app = appModule.app;
+  resetRateLimitBuckets = rateLimitModule.resetRateLimitBuckets;
+});
+
+beforeEach(() => {
+  resetRateLimitBuckets();
+  globalThis.fetch = originalFetch;
+});
+
+describe('GET /api/v1/health/ready — aggregated readiness', () => {
+  it('returns all-up (ready) when every upstream is healthy', async () => {
+    let callCount = 0;
+    globalThis.fetch = (async () => {
+      callCount += 1;
+      return new Response(JSON.stringify({ status: 'ready' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const response = await app.handle(new Request('http://localhost/api/v1/health/ready'));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      status: string;
+      service: string;
+      timestamp: string;
+      upstreams: Array<{ id: string; serviceName: string; status: string; latency: number }>;
+    };
+
+    expect(body.status).toBe('ready');
+    expect(body.service).toBe('api-gateway');
+    expect(body.timestamp).toBeDefined();
+    expect(body.upstreams).toHaveLength(2);
+    expect(callCount).toBe(2);
+
+    const nestApi = body.upstreams.find(u => u.id === 'nest-api');
+    const bunApi = body.upstreams.find(u => u.id === 'bun-api');
+
+    expect(nestApi?.status).toBe('healthy');
+    expect(nestApi?.serviceName).toBe('todo-api');
+    expect(typeof nestApi?.latency).toBe('number');
+
+    expect(bunApi?.status).toBe('healthy');
+    expect(bunApi?.serviceName).toBe('todo-api-bun');
+    expect(typeof bunApi?.latency).toBe('number');
+  });
+
+  it('returns partial-down when one upstream is healthy and one is unhealthy', async () => {
+    let callIndex = -1;
+    globalThis.fetch = (async () => {
+      callIndex += 1;
+      if (callIndex === 0) {
+        // First upstream (nest-api) fails
+        return new Response('Service Unavailable', { status: 503 });
+      }
+      // Second upstream (bun-api) succeeds
+      return new Response(JSON.stringify({ status: 'ready' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const response = await app.handle(new Request('http://localhost/api/v1/health/ready'));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      status: string;
+      upstreams: Array<{ id: string; status: string; latency: number; error?: string }>;
+    };
+
+    expect(body.status).toBe('partial-down');
+    expect(body.upstreams).toHaveLength(2);
+
+    const nestApi = body.upstreams.find(u => u.id === 'nest-api');
+    const bunApi = body.upstreams.find(u => u.id === 'bun-api');
+
+    expect(nestApi?.status).toBe('unhealthy');
+    expect(nestApi?.error).toBeDefined();
+    expect(typeof nestApi?.latency).toBe('number');
+
+    expect(bunApi?.status).toBe('healthy');
+    expect(bunApi?.error).toBeUndefined();
+    expect(typeof bunApi?.latency).toBe('number');
+  });
+
+  it('returns all-down when every upstream is unhealthy', async () => {
+    globalThis.fetch = (async () => {
+      return new Response('Service Unavailable', { status: 503 });
+    }) as unknown as typeof fetch;
+
+    const response = await app.handle(new Request('http://localhost/api/v1/health/ready'));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      status: string;
+      upstreams: Array<{ id: string; status: string; latency: number; error?: string }>;
+    };
+
+    expect(body.status).toBe('all-down');
+    expect(body.upstreams).toHaveLength(2);
+
+    for (const upstream of body.upstreams) {
+      expect(upstream.status).toBe('unhealthy');
+      expect(upstream.error).toBeDefined();
+      expect(typeof upstream.latency).toBe('number');
+    }
+  });
+
+  it('includes per-upstream id, serviceName, status, latency, and error for unhealthy upstreams', async () => {
+    globalThis.fetch = (async () => {
+      return new Response('Bad Gateway', { status: 502 });
+    }) as unknown as typeof fetch;
+
+    const response = await app.handle(new Request('http://localhost/api/v1/health/ready'));
+    const body = (await response.json()) as {
+      upstreams: Array<{
+        id: string;
+        serviceName: string;
+        status: string;
+        latency: number;
+        error?: string;
+      }>;
+    };
+
+    for (const upstream of body.upstreams) {
+      expect(upstream.id).toBeOneOf(['nest-api', 'bun-api']);
+      expect(upstream.serviceName).toBeOneOf(['todo-api', 'todo-api-bun']);
+      expect(upstream.status).toBe('unhealthy');
+      expect(typeof upstream.latency).toBe('number');
+      expect(upstream.error).toBe('HTTP 502');
+    }
+  });
+
+  it('preserves existing gateway health metadata endpoint', async () => {
+    const response = await app.handle(new Request('http://localhost/api/v1/health'));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { service: string; version: string; timestamp: string };
+    expect(body.service).toBe('api-gateway');
+    expect(body.version).toBe('0.0.1');
+    expect(body.timestamp).toBeDefined();
+  });
+
+  it('preserves existing gateway index endpoint', async () => {
+    const response = await app.handle(new Request('http://localhost/api/v1'));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { service: string; version: string; timestamp: string };
+    expect(body.service).toBe('api-gateway');
+    expect(body.version).toBe('0.0.1');
+    expect(body.timestamp).toBeDefined();
+  });
+});

--- a/apps/api-gateway/src/routes/index.route.ts
+++ b/apps/api-gateway/src/routes/index.route.ts
@@ -1,16 +1,89 @@
 import { Elysia } from 'elysia';
 
+import { upstreams } from '../config/upstreams';
+import { type Upstream } from '../types/upstream';
+
+const READINESS_TIMEOUT_MS = 5_000;
+
 const gatewayMetadata = () => ({
   service: 'api-gateway',
   version: '0.0.1',
   timestamp: new Date().toISOString(),
 });
 
+export interface UpstreamHealth {
+  id: Upstream['id'];
+  serviceName: Upstream['serviceName'];
+  status: 'healthy' | 'unhealthy';
+  latency: number;
+  error?: string;
+}
+
+async function checkUpstreamHealth(upstream: Upstream): Promise<UpstreamHealth> {
+  const url = `${upstream.baseUrl}${upstream.healthPath}`;
+  const startedAt = performance.now();
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), READINESS_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetch(url, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const latency = Math.round((performance.now() - startedAt) * 100) / 100;
+
+    if (response.ok) {
+      return { id: upstream.id, serviceName: upstream.serviceName, status: 'healthy', latency };
+    }
+
+    return {
+      id: upstream.id,
+      serviceName: upstream.serviceName,
+      status: 'unhealthy',
+      latency,
+      error: `HTTP ${response.status}`,
+    };
+  } catch (error) {
+    const latency = Math.round((performance.now() - startedAt) * 100) / 100;
+    return {
+      id: upstream.id,
+      serviceName: upstream.serviceName,
+      status: 'unhealthy',
+      latency,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+async function readinessHandler() {
+  const upstreamEntries = Object.values(upstreams);
+  const results = await Promise.all(upstreamEntries.map(checkUpstreamHealth));
+
+  const healthyCount = results.filter(r => r.status === 'healthy').length;
+  const totalCount = results.length;
+
+  let status: 'ready' | 'partial-down' | 'all-down';
+  if (healthyCount === totalCount) {
+    status = 'ready';
+  } else if (healthyCount === 0) {
+    status = 'all-down';
+  } else {
+    status = 'partial-down';
+  }
+
+  return {
+    status,
+    service: 'api-gateway',
+    timestamp: new Date().toISOString(),
+    upstreams: results,
+  };
+}
+
 export const indexRoute = new Elysia()
   .get('/api/v1', gatewayMetadata)
   .get('/api/v1/health', gatewayMetadata)
-  .get('/api/v1/health/ready', () => ({
-    status: 'ready',
-    service: 'api-gateway',
-    timestamp: new Date().toISOString(),
-  }));
+  .get('/api/v1/health/ready', readinessHandler);


### PR DESCRIPTION
## Summary
Implements: Implement aggregated gateway readiness checks with direct validation.

## Task
Acceptance criteria:
- Implement GET /api/v1/health/ready aggregation for configured upstreams.
- Include per-upstream id, service name, status, latency, and error information when an upstream is unhealthy.
- Return all-up when every upstream is healthy, partial-down when one upstream fails, and all-down when all upstreams fail.
- Add deterministic tests for all-up, partial-down, and all-down states using mocked fetch responses.
- Preserve existing gateway health and proxy behavior.

Non-goals:
- Do not expand beyond the requested task scope.
- Do not merge this PR without human review.

## Changes
- Updates the source and test files needed for the requested behavior.
- Keeps the change focused on the task acceptance criteria.

## Validation
- `bun test apps/api-gateway/src/__tests__/app.test.ts apps/api-gateway/src/__tests__/health.test.ts`
- `bunx tsc --noEmit -p apps/api-gateway/tsconfig.json`

## Review
- Review the changed files against the task acceptance criteria.
- Confirm the implementation remains compatible with existing behavior.

## Risk
- Human review is required before merge.
- Main residual risk is whether the added or changed tests cover all intended edge cases.