### PR TITLE
CI-001: Harden MongoMemoryServer and TodoForm tests for CI

### DIFF
--- a/apps/api-bun/test/auth.test.ts
+++ b/apps/api-bun/test/auth.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test'
 
 import mongoose from 'mongoose';
 
+import { resolveTestMongoUri } from './mongo-test-helper';
 import { app } from '../src/app';
 import { User } from '../src/modules/user/user.model';
-import { resolveTestMongoUri } from './mongo-test-helper';
 
 describe('Auth Integration', () => {
   let stopMongo: () => Promise<void>;

--- a/apps/api-bun/test/auth.test.ts
+++ b/apps/api-bun/test/auth.test.ts
@@ -1,23 +1,23 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 
 import { app } from '../src/app';
 import { User } from '../src/modules/user/user.model';
+import { resolveTestMongoUri } from './mongo-test-helper';
 
 describe('Auth Integration', () => {
-  let mongod: MongoMemoryServer;
+  let stopMongo: () => Promise<void>;
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const { uri, stop } = await resolveTestMongoUri();
+    stopMongo = stop;
     await mongoose.connect(uri);
   });
 
   afterAll(async () => {
     await mongoose.disconnect();
-    await mongod.stop();
+    if (stopMongo) await stopMongo();
   });
 
   beforeEach(async () => {

--- a/apps/api-bun/test/db-smoke.test.ts
+++ b/apps/api-bun/test/db-smoke.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 
 import mongoose from 'mongoose';
 
+import { resolveTestMongoUri } from './mongo-test-helper';
 import { Todo } from '../src/modules/todo/todo.model';
 import { User } from '../src/modules/user/user.model';
-import { resolveTestMongoUri } from './mongo-test-helper';
 
 describe('Database Smoke Test', () => {
   let stopMongo: () => Promise<void>;

--- a/apps/api-bun/test/db-smoke.test.ts
+++ b/apps/api-bun/test/db-smoke.test.ts
@@ -1,23 +1,23 @@
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 
 import { Todo } from '../src/modules/todo/todo.model';
 import { User } from '../src/modules/user/user.model';
+import { resolveTestMongoUri } from './mongo-test-helper';
 
 describe('Database Smoke Test', () => {
-  let mongod: MongoMemoryServer;
+  let stopMongo: () => Promise<void>;
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const { uri, stop } = await resolveTestMongoUri();
+    stopMongo = stop;
     await mongoose.connect(uri);
   }, 30000);
 
   afterAll(async () => {
     await mongoose.disconnect();
-    await mongod?.stop();
+    if (stopMongo) await stopMongo();
   }, 30000);
 
   it('should create and save a user with hashed password', async () => {

--- a/apps/api-bun/test/modules/auth/auth.service.test.ts
+++ b/apps/api-bun/test/modules/auth/auth.service.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, mock } from 'bun:test';
 
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 
 import { AuthService, type JwtSigner } from '../../../src/modules/auth/auth.service';
 import { User } from '../../../src/modules/user/user.model';
 import { UserService } from '../../../src/modules/user/user.service';
 import { UnauthorizedError, ConflictError } from '../../../src/plugins/errors';
+import { resolveTestMongoUri } from '../../mongo-test-helper';
 
 describe('AuthService', () => {
-  let mongod: MongoMemoryServer;
+  let stopMongo: () => Promise<void>;
   let userService: UserService;
   let authService: AuthService;
 
@@ -18,8 +18,8 @@ describe('AuthService', () => {
   };
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const { uri, stop } = await resolveTestMongoUri();
+    stopMongo = stop;
     await mongoose.connect(uri);
     userService = new UserService();
     authService = new AuthService(userService);
@@ -27,7 +27,7 @@ describe('AuthService', () => {
 
   afterAll(async () => {
     await mongoose.disconnect();
-    await mongod.stop();
+    if (stopMongo) await stopMongo();
   });
 
   beforeEach(async () => {

--- a/apps/api-bun/test/modules/health/health.test.ts
+++ b/apps/api-bun/test/modules/health/health.test.ts
@@ -1,25 +1,26 @@
 import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
 
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 
 import { app } from '../../../src/app';
 import { cache } from '../../../src/cache';
 import { type HealthResponse, type ReadinessResponse } from '../../../src/schemas/health';
+import { resolveTestMongoUri } from '../../mongo-test-helper';
 
 describe('Health Module', () => {
-  let mongod: MongoMemoryServer;
+  let stopMongo: () => Promise<void>;
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    await mongoose.connect(mongod.getUri());
+    const { uri, stop } = await resolveTestMongoUri();
+    stopMongo = stop;
+    await mongoose.connect(uri);
     await cache.initialize();
   });
 
   afterAll(async () => {
     await cache.quit();
     await mongoose.disconnect();
-    await mongod.stop();
+    if (stopMongo) await stopMongo();
   });
 
   describe('GET /api/v1/health', () => {

--- a/apps/api-bun/test/modules/user/user.integration.test.ts
+++ b/apps/api-bun/test/modules/user/user.integration.test.ts
@@ -2,15 +2,15 @@ import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 
 import { jwt } from '@elysiajs/jwt';
 import { Elysia } from 'elysia';
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 
 import { app } from '../../../src/app';
 import { config } from '../../../src/config/env';
 import { User } from '../../../src/modules/user/user.model';
+import { resolveTestMongoUri } from '../../mongo-test-helper';
 
 describe('User Integration', () => {
-  let mongod: MongoMemoryServer;
+  let stopMongo: () => Promise<void>;
 
   // Helper to sign a token for testing
   const signToken = async (sub: string, email: string) => {
@@ -25,14 +25,14 @@ describe('User Integration', () => {
   };
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const { uri, stop } = await resolveTestMongoUri();
+    stopMongo = stop;
     await mongoose.connect(uri);
   });
 
   afterAll(async () => {
     await mongoose.disconnect();
-    await mongod.stop();
+    if (stopMongo) await stopMongo();
   });
 
   describe('GET /api/v1/users/profile', () => {

--- a/apps/api-bun/test/modules/user/user.service.test.ts
+++ b/apps/api-bun/test/modules/user/user.service.test.ts
@@ -1,26 +1,26 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 
 import { User } from '../../../src/modules/user/user.model';
 import { UserService } from '../../../src/modules/user/user.service';
 import { ConflictError, NotFoundError } from '../../../src/plugins/errors';
+import { resolveTestMongoUri } from '../../mongo-test-helper';
 
 describe('UserService', () => {
-  let mongod: MongoMemoryServer;
+  let stopMongo: () => Promise<void>;
   let userService: UserService;
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const { uri, stop } = await resolveTestMongoUri();
+    stopMongo = stop;
     await mongoose.connect(uri);
     userService = new UserService();
   });
 
   afterAll(async () => {
     await mongoose.disconnect();
-    await mongod.stop();
+    if (stopMongo) await stopMongo();
   });
 
   beforeEach(async () => {

--- a/apps/api-bun/test/mongo-test-helper.ts
+++ b/apps/api-bun/test/mongo-test-helper.ts
@@ -1,0 +1,38 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+
+/**
+ * Resolve a MongoDB URI for tests with associated lifecycle cleanup.
+ *
+ * When MONGODB_URI is already set (e.g. CI service container), use it directly.
+ * Otherwise start an in-memory MongoMemoryServer.
+ *
+ * Compare the return pattern:
+ *   const { uri, stop } = await resolveTestMongoUri();
+ *   // ... connect with uri ...
+ *   await stop(); // in afterAll
+ */
+export async function resolveTestMongoUri(): Promise<{
+  uri: string;
+  stop: () => Promise<void>;
+}> {
+  const existingUri = process.env.MONGODB_URI;
+  if (existingUri) {
+    return {
+      uri: existingUri,
+      stop: async () => {
+        /* shared CI service — do not manage its lifecycle */
+      },
+    };
+  }
+
+  const mongod = await MongoMemoryServer.create();
+  const uri = mongod.getUri();
+  return {
+    uri,
+    stop: async () => {
+      await mongoose.disconnect();
+      await mongod.stop();
+    },
+  };
+}

--- a/apps/api-bun/test/todo.test.ts
+++ b/apps/api-bun/test/todo.test.ts
@@ -1,21 +1,21 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 
 import { app } from '../src/app';
 import { cache } from '../src/cache';
 import { Todo } from '../src/modules/todo/todo.model';
 import { User } from '../src/modules/user/user.model';
+import { resolveTestMongoUri } from './mongo-test-helper';
 
 describe('Todo Integration', () => {
-  let mongod: MongoMemoryServer;
+  let stopMongo: () => Promise<void>;
   let authToken: string;
   let userId: string;
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const { uri, stop } = await resolveTestMongoUri();
+    stopMongo = stop;
     await mongoose.connect(uri);
     await cache.initialize();
   });
@@ -23,7 +23,7 @@ describe('Todo Integration', () => {
   afterAll(async () => {
     await cache.quit();
     await mongoose.disconnect();
-    await mongod.stop();
+    if (stopMongo) await stopMongo();
   });
 
   beforeEach(async () => {

--- a/apps/api-bun/test/todo.test.ts
+++ b/apps/api-bun/test/todo.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test'
 
 import mongoose from 'mongoose';
 
+import { resolveTestMongoUri } from './mongo-test-helper';
 import { app } from '../src/app';
 import { cache } from '../src/cache';
 import { Todo } from '../src/modules/todo/todo.model';
 import { User } from '../src/modules/user/user.model';
-import { resolveTestMongoUri } from './mongo-test-helper';
 
 describe('Todo Integration', () => {
   let stopMongo: () => Promise<void>;

--- a/apps/api/test/setup.ts
+++ b/apps/api/test/setup.ts
@@ -1,8 +1,14 @@
 import { MongoMemoryServer } from 'mongodb-memory-server';
 
-let mongod: MongoMemoryServer;
+let mongod: MongoMemoryServer | null = null;
 
 beforeAll(async () => {
+  // When MONGODB_URI is already set (e.g. CI service container), use it directly
+  // to avoid concurrent mongod binary download/exec across parallel test suites.
+  const existingUri = process.env.MONGODB_URI;
+  if (existingUri) {
+    return;
+  }
   mongod = await MongoMemoryServer.create();
   const uri = mongod.getUri();
   process.env.MONGODB_URI = uri;

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -11,6 +11,7 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   ...baseConfig,
   setupFilesAfterEnv: ['<rootDir>/../../packages/config-jest/setup-tests.js', '<rootDir>/jest.setup.js'],
+  testTimeout: 15000, // CI runners are slower; 5s default causes flaky timeouts
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@todo/utils/(.*)$': '<rootDir>/../../packages/utils/src/$1',

--- a/apps/web/src/components/__tests__/TodoForm.test.tsx
+++ b/apps/web/src/components/__tests__/TodoForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { TodoForm, type TodoFormData } from '../todo/TodoForm';
@@ -187,7 +187,9 @@ describe('TodoForm', () => {
       await user.type(screen.getByLabelText('Tags'), 'test-tag');
       await user.click(screen.getByRole('button', { name: 'Add' }));
 
-      expect(screen.getByText('test-tag')).toBeInTheDocument();
+      // Use findByText — tag rendering involves a state update that may not
+      // be settled on slow CI runners with synchronous getByText.
+      expect(await screen.findByText('test-tag')).toBeInTheDocument();
       expect(screen.getByLabelText('Tags')).toHaveValue('');
     });
 
@@ -199,7 +201,8 @@ describe('TodoForm', () => {
       await user.type(tagInput, 'test-tag');
       await user.keyboard('{Enter}');
 
-      expect(screen.getByText('test-tag')).toBeInTheDocument();
+      // Use findByText — Enter key triggers addTag which calls setState
+      expect(await screen.findByText('test-tag')).toBeInTheDocument();
       expect(tagInput).toHaveValue('');
     });
 
@@ -213,7 +216,9 @@ describe('TodoForm', () => {
       await user.type(screen.getByLabelText('Tags'), 'duplicate');
       await user.click(screen.getByRole('button', { name: 'Add' }));
 
-      expect(screen.getAllByText('duplicate')).toHaveLength(1);
+      // Use findAllByText and await — duplicate assertion needs DOM settled
+      const tags = await screen.findAllByText('duplicate');
+      expect(tags).toHaveLength(1);
     });
 
     it('removes tags when remove button is clicked', async () => {
@@ -221,11 +226,14 @@ describe('TodoForm', () => {
       const initialData = { title: 'Test', priority: 'medium' as const, tags: ['removeme'] };
       render(<TodoForm onSubmit={mockOnSubmit} initialData={initialData} />);
 
-      expect(screen.getByText('removeme')).toBeInTheDocument();
+      expect(await screen.findByText('removeme')).toBeInTheDocument();
 
       await user.click(screen.getByRole('button', { name: 'Remove removeme tag' }));
 
-      expect(screen.queryByText('removeme')).not.toBeInTheDocument();
+      // Wait for removal to settle before asserting absence
+      await waitFor(() => {
+        expect(screen.queryByText('removeme')).not.toBeInTheDocument();
+      });
     });
 
     it('prevents adding more than 10 tags', async () => {
@@ -237,10 +245,17 @@ describe('TodoForm', () => {
       };
       render(<TodoForm onSubmit={mockOnSubmit} initialData={initialData} />);
 
+      // Verify all 10 initial tags render
+      for (let i = 0; i < 10; i++) {
+        expect(await screen.findByText(`tag${i}`)).toBeInTheDocument();
+      }
+
       await user.type(screen.getByLabelText('Tags'), 'extra-tag');
       await user.click(screen.getByRole('button', { name: 'Add' }));
 
-      expect(screen.queryByText('extra-tag')).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByText('extra-tag')).not.toBeInTheDocument();
+      });
     });
 
     it('includes tags in form submission', async () => {


### PR DESCRIPTION
## Summary

Two CI-hardening fixes for verified pre-existing failures without skipping or weakening tests.

### 1. MongoMemoryServer ETXTBSY (apps/api + apps/api-bun)

**Root cause:** Turborepo runs `@todo/api#test` (NestJS) and `@todo/api-bun#test` (Bun) concurrently. Both suites call `MongoMemoryServer.create()`, which downloads and executes the same mongod binary from the shared cache. On a fresh CI runner this produces `spawn ETXTBSY` when multiple processes try to write/execute the binary simultaneously.

**Fix:** When `MONGODB_URI` is already set (CI provides a MongoDB service container), skip MongoMemoryServer entirely and use the CI URI directly.

- `apps/api/test/setup.ts` — checks `process.env.MONGODB_URI` before starting an in-memory mongod
- `apps/api-bun/test/mongo-test-helper.ts` — new shared utility `resolveTestMongoUri()` used across all 7 affected Bun test files
- `apps/api-bun/test/{auth,db-smoke,todo}.test.ts` + 4 module test files — migrated to the helper

**Effect:** Zero concurrent mongod binary downloads in CI. The single CI MongoDB service is the source of truth. Local development continues to use in-memory MongoDB as before.

### 2. TodoForm test timeout (apps/web)

**Root cause:** On slower CI runners, `userEvent.type()` + `userEvent.click()` sequences in Tag Management tests (up to 6 interactions per test) exceed the 5s Jest default timeout. Synchronous `getByText`/ assertions fire before React state updates settle.

**Fix:**
- Increased `testTimeout` from 5s to 15s in `apps/web/jest.config.js`
- Replaced synchronous DOM queries with async `findByText`// after state-changing user events

### Validation

| Suite | Tests | Status |
|-------|-------|--------|
| @todo/web#test | 182 | ✅ Pass |
| @todo/api#test | 95 | ✅ Pass |
| @todo/api-bun#test | 86 | ✅ Pass |
| Lint (api, web) | — | ✅ Clean |
| Typecheck (api, api-bun, web) | — | ✅ Clean |

## Related

Fixes the two failures reproduced in GitHub runs #30102622466 and #30103241223.