### PR TITLE
feat: Add saved todo filter views across web todo components

### DIFF
--- a/apps/web/src/app/todos/page.tsx
+++ b/apps/web/src/app/todos/page.tsx
@@ -4,7 +4,12 @@ import { useState, useEffect, useMemo } from 'react';
 import { Alert, Button, BlockchainStats, FloatingActionButton, useToast } from '@todo/ui-web';
 import { TodoFormModal } from '@/components/todo/TodoFormModal';
 import { TodoList } from '@/components/todo/TodoList';
-import { TodoFilters, type PriorityFilter, type StatusFilter } from '@/components/todo/TodoFilters';
+import {
+  TodoFilters,
+  type PriorityFilter,
+  type StatusFilter,
+  type SavedFilterView,
+} from '@/components/todo/TodoFilters';
 import { TodoBulkActions } from '@/components/todo/TodoBulkActions';
 import { useTodoStore } from '@/store/todoStore';
 import { useWallet } from '@/components/WalletProvider';
@@ -17,6 +22,7 @@ const TodosPage = () => {
   const [search, setSearch] = useState('');
   const [priority, setPriority] = useState<PriorityFilter>('all');
   const [status, setStatus] = useState<StatusFilter>('all');
+  const [activeViewId, setActiveViewId] = useState<string | undefined>(undefined);
 
   const {
     todos,
@@ -32,6 +38,9 @@ const TodosPage = () => {
     canUndo,
     syncToBlockchain,
     fetchTodos,
+    savedViews,
+    addSavedView,
+    deleteSavedView,
   } = useTodoStore();
 
   const { isConnected, supportedNetworks } = useWallet();
@@ -108,6 +117,31 @@ const TodosPage = () => {
     setSearch('');
     setPriority('all');
     setStatus('all');
+    setActiveViewId(undefined);
+  };
+
+  const handleSelectView = (view: SavedFilterView) => {
+    setSearch(view.search);
+    setPriority(view.priority);
+    setStatus(view.status);
+    setActiveViewId(view.id);
+  };
+
+  const handleSaveView = (name: string) => {
+    addSavedView({
+      name,
+      search,
+      priority,
+      status,
+    });
+    setActiveViewId(undefined);
+  };
+
+  const handleDeleteView = (id: string) => {
+    deleteSavedView(id);
+    if (activeViewId === id) {
+      setActiveViewId(undefined);
+    }
   };
 
   const handleRefresh = () => {
@@ -260,12 +294,26 @@ const TodosPage = () => {
 
       <TodoFilters
         search={search}
-        onSearchChange={setSearch}
+        onSearchChange={value => {
+          setSearch(value);
+          setActiveViewId(undefined);
+        }}
         priority={priority}
-        onPriorityChange={setPriority}
+        onPriorityChange={value => {
+          setPriority(value);
+          setActiveViewId(undefined);
+        }}
         status={status}
-        onStatusChange={setStatus}
+        onStatusChange={value => {
+          setStatus(value);
+          setActiveViewId(undefined);
+        }}
         onClear={handleClearFilters}
+        savedViews={savedViews}
+        activeViewId={activeViewId}
+        onSelectView={handleSelectView}
+        onSaveView={handleSaveView}
+        onDeleteView={handleDeleteView}
       />
 
       <TodoBulkActions

--- a/apps/web/src/components/__tests__/TodoList.test.tsx
+++ b/apps/web/src/components/__tests__/TodoList.test.tsx
@@ -488,4 +488,86 @@ describe('TodoList', () => {
       expect(screen.getAllByRole('checkbox')).toHaveLength(5);
     });
   });
+
+  describe('Saved Views', () => {
+    const mockViews = [
+      {
+        id: 'v1',
+        name: 'High Priority',
+        search: '',
+        priority: 'high' as const,
+        status: 'all' as const,
+        sort: 'priority' as const,
+      },
+      {
+        id: 'v2',
+        name: 'Today',
+        search: '',
+        priority: 'all' as const,
+        status: 'open' as const,
+        sort: 'created' as const,
+      },
+      {
+        id: 'v3',
+        name: 'Blockchain',
+        search: 'blockchain',
+        priority: 'all' as const,
+        status: 'all' as const,
+        sort: 'created' as const,
+      },
+    ];
+
+    it('renders saved view buttons when savedViews is provided', () => {
+      render(<TodoList {...defaultProps} savedViews={mockViews} />);
+
+      expect(screen.getByText('High Priority')).toBeInTheDocument();
+      expect(screen.getByText('Today')).toBeInTheDocument();
+      expect(screen.getByText('Blockchain')).toBeInTheDocument();
+    });
+
+    it('selecting a saved view applies its filter and sort', async () => {
+      const user = userEvent.setup();
+      render(<TodoList {...defaultProps} savedViews={mockViews} />);
+
+      // Click "High Priority" saved view
+      await user.click(screen.getByText('High Priority'));
+
+      // The filter/sort select should reflect "Active" (all non-completed) and "Priority"
+      const sortSelect = screen.getByDisplayValue('Priority');
+      expect(sortSelect).toBeInTheDocument();
+    });
+
+    it('calls onSelectView when a saved view is clicked', async () => {
+      const onSelectView = jest.fn();
+      const user = userEvent.setup();
+      render(<TodoList {...defaultProps} savedViews={mockViews} onSelectView={onSelectView} />);
+
+      await user.click(screen.getByText('Today'));
+      expect(onSelectView).toHaveBeenCalledWith(mockViews[1]);
+    });
+
+    it('calls onDeleteView when delete button is clicked', async () => {
+      const onDeleteView = jest.fn();
+      const user = userEvent.setup();
+      render(<TodoList {...defaultProps} savedViews={mockViews} onDeleteView={onDeleteView} />);
+
+      await user.click(screen.getByLabelText('Delete saved view Blockchain'));
+      expect(onDeleteView).toHaveBeenCalledWith('v3');
+    });
+
+    it('clears saved view highlight when changing manual filters', async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(<TodoList {...defaultProps} savedViews={mockViews} activeViewId="v1" />);
+
+      // Change search filters manually
+      const searchInput = screen.getByPlaceholderText('Search todos...');
+      await user.type(searchInput, 'test');
+
+      // After rerender without activeViewId, the highlight should be gone
+      rerender(<TodoList {...defaultProps} savedViews={mockViews} />);
+
+      // All saved view buttons should still be present
+      expect(screen.getByText('High Priority')).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -14,14 +14,15 @@ export {
 // Todo Components
 export { TodoForm, todoFormVariants, type TodoFormData, type TodoFormProps } from './todo/TodoForm';
 export { TodoItem, todoItemVariants, type TodoData, type TodoItemProps } from './todo/TodoItem';
+export { TodoList, todoListVariants, type TodoListProps, type TodoListStats, type FilterType } from './todo/TodoList';
 export {
-  TodoList,
-  todoListVariants,
-  type TodoListProps,
-  type TodoListStats,
-  type FilterType,
+  TodoFilters,
+  type TodoFiltersProps,
+  type PriorityFilter,
+  type StatusFilter,
+  type SavedFilterView,
   type SortType,
-} from './todo/TodoList';
+} from './todo/TodoFilters';
 
 // Wallet Provider Components
 export {

--- a/apps/web/src/components/todo/TodoFilters.tsx
+++ b/apps/web/src/components/todo/TodoFilters.tsx
@@ -5,6 +5,16 @@ import { Button, ButtonGroup, Input } from '@todo/ui-web';
 
 export type PriorityFilter = 'all' | 'low' | 'medium' | 'high';
 export type StatusFilter = 'all' | 'open' | 'completed';
+export type SortType = 'created' | 'priority' | 'dueDate' | 'title';
+
+export interface SavedFilterView {
+  id: string;
+  name: string;
+  search: string;
+  priority: PriorityFilter;
+  status: StatusFilter;
+  sort?: SortType;
+}
 
 export interface TodoFiltersProps {
   search: string;
@@ -14,6 +24,11 @@ export interface TodoFiltersProps {
   status: StatusFilter;
   onStatusChange: (status: StatusFilter) => void;
   onClear?: () => void;
+  savedViews?: SavedFilterView[];
+  activeViewId?: string;
+  onSelectView?: (view: SavedFilterView) => void;
+  onSaveView?: (name: string) => void;
+  onDeleteView?: (id: string) => void;
 }
 
 const PRIORITY_OPTIONS = ['all', 'low', 'medium', 'high'] as const;
@@ -27,11 +42,69 @@ export const TodoFilters: React.FC<TodoFiltersProps> = ({
   status,
   onStatusChange,
   onClear,
+  savedViews,
+  activeViewId,
+  onSelectView,
+  onSaveView,
+  onDeleteView,
 }) => {
+  const [newViewName, setNewViewName] = React.useState('');
   const hasActiveFilters = search.trim().length > 0 || priority !== 'all' || status !== 'all';
+
+  const handleSaveView = () => {
+    const name = newViewName.trim() || `View ${(savedViews?.length ?? 0) + 1}`;
+    onSaveView?.(name);
+    setNewViewName('');
+  };
 
   return (
     <div className="space-y-4 rounded-lg border border-base-300 bg-base-100 p-4 shadow-sm">
+      {/* Saved Views */}
+      {savedViews && savedViews.length > 0 && (
+        <div className="space-y-2">
+          <div className="text-sm font-medium text-base-content">Saved Views</div>
+          <div className="flex flex-wrap gap-2">
+            {savedViews.map(view => (
+              <div key={view.id} className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  size="xs"
+                  variant={activeViewId === view.id ? 'default' : 'outline'}
+                  onClick={() => onSelectView?.(view)}
+                >
+                  {view.name}
+                </Button>
+                {onDeleteView && (
+                  <button
+                    type="button"
+                    className="btn btn-ghost btn-xs text-base-content/50 hover:text-error"
+                    aria-label={`Delete saved view ${view.name}`}
+                    onClick={() => onDeleteView(view.id)}
+                  >
+                    &times;
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Save current view */}
+      {hasActiveFilters && onSaveView && (
+        <div className="flex items-center gap-2">
+          <Input
+            type="text"
+            value={newViewName}
+            onChange={e => setNewViewName(e.target.value)}
+            placeholder="View name..."
+            className="flex-1"
+          />
+          <Button type="button" size="sm" variant="outline" onClick={handleSaveView}>
+            Save view
+          </Button>
+        </div>
+      )}
       <div className="space-y-2">
         <label htmlFor="todo-filter-search" className="text-sm font-medium text-base-content">
           Search

--- a/apps/web/src/components/todo/TodoList.tsx
+++ b/apps/web/src/components/todo/TodoList.tsx
@@ -5,6 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { Button, cn, Input, Select } from '@todo/ui-web';
 import { type TodoData, TodoItem } from './TodoItem';
 import { type BlockchainNetwork } from '@todo/services';
+import type { SavedFilterView, SortType } from './TodoFilters';
 
 const todoListVariants = cva('w-full', {
   variants: {
@@ -26,7 +27,6 @@ const todoListVariants = cva('w-full', {
 });
 
 export type FilterType = 'all' | 'active' | 'completed';
-export type SortType = 'created' | 'priority' | 'dueDate' | 'title';
 
 export interface TodoListStats {
   total: number;
@@ -50,6 +50,11 @@ export interface TodoListProps
   initialFilter?: FilterType;
   initialSort?: SortType;
   initialSearchTerm?: string;
+  savedViews?: SavedFilterView[];
+  activeViewId?: string;
+  onSelectView?: (view: SavedFilterView) => void;
+  onSaveView?: (name: string) => void;
+  onDeleteView?: (id: string) => void;
   TransactionStatusComponent?: React.ComponentType<{
     transactionHash: string;
     network: BlockchainNetwork;
@@ -81,6 +86,11 @@ const TodoList = React.forwardRef<HTMLDivElement, TodoListProps>(
       TransactionStatusComponent,
       getNetworkDisplayInfo,
       supportedNetworks,
+      savedViews,
+      activeViewId,
+      onSelectView,
+      onSaveView,
+      onDeleteView,
       onRefresh,
       refreshing = false,
       ...props
@@ -90,6 +100,7 @@ const TodoList = React.forwardRef<HTMLDivElement, TodoListProps>(
     const [filter, setFilter] = useState<FilterType>(initialFilter);
     const [sort, setSort] = useState<SortType>(initialSort);
     const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
+    const [newViewName, setNewViewName] = useState('');
 
     const filteredAndSortedTodos = useMemo(() => {
       let filtered = todos;
@@ -160,6 +171,74 @@ const TodoList = React.forwardRef<HTMLDivElement, TodoListProps>(
     const handleSortChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
       setSort(e.target.value as SortType);
     }, []);
+
+    const renderSavedViews = () => {
+      if (!savedViews || savedViews.length === 0) return null;
+
+      return (
+        <div className="mb-3 space-y-2">
+          <div className="text-sm font-medium text-base-content">Saved Views</div>
+          <div className="flex flex-wrap gap-2">
+            {savedViews.map(view => (
+              <div key={view.id} className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  size="xs"
+                  variant={activeViewId === view.id ? 'default' : 'outline'}
+                  onClick={() => {
+                    onSelectView?.(view);
+                    setFilter(view.status === 'open' ? 'active' : view.status === 'completed' ? 'completed' : 'all');
+                    setSort(view.sort ?? 'created');
+                    setSearchTerm(view.search);
+                  }}
+                >
+                  {view.name}
+                </Button>
+                {onDeleteView && (
+                  <button
+                    type="button"
+                    className="btn btn-ghost btn-xs text-base-content/50 hover:text-error"
+                    aria-label={`Delete saved view ${view.name}`}
+                    onClick={() => onDeleteView(view.id)}
+                  >
+                    &times;
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+    };
+
+    const renderSaveViewInput = () => {
+      const hasActiveFilters = filter !== 'all' || searchTerm.trim().length > 0 || sort !== 'created';
+      if (!hasActiveFilters || !onSaveView) return null;
+
+      return (
+        <div className="mt-2 flex items-center gap-2">
+          <Input
+            type="text"
+            value={newViewName}
+            onChange={e => setNewViewName(e.target.value)}
+            placeholder="View name..."
+            className="flex-1"
+          />
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              const name = newViewName.trim() || `View ${(savedViews?.length ?? 0) + 1}`;
+              onSaveView(name);
+              setNewViewName('');
+            }}
+          >
+            Save view
+          </Button>
+        </div>
+      );
+    };
 
     const renderEmptyState = () => {
       if (emptyState) {
@@ -234,6 +313,7 @@ const TodoList = React.forwardRef<HTMLDivElement, TodoListProps>(
 
       return (
         <div className="bg-base-100 p-4 rounded-lg shadow-sm border border-base-300">
+          {renderSavedViews()}
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-3 sm:space-y-0 sm:space-x-4">
             <div className="flex-1">
               <Input
@@ -260,6 +340,7 @@ const TodoList = React.forwardRef<HTMLDivElement, TodoListProps>(
               </Select>
             </div>
           </div>
+          {renderSaveViewInput()}
           <div className="mt-2 text-sm text-base-content/70">{filteredAndSortedTodos.length} todos to display</div>
         </div>
       );

--- a/apps/web/src/components/todo/__tests__/TodoFilters.test.tsx
+++ b/apps/web/src/components/todo/__tests__/TodoFilters.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { TodoFilters } from '../TodoFilters';
+import { TodoFilters, type SavedFilterView } from '../TodoFilters';
 
 describe('TodoFilters', () => {
   it('renders correctly', () => {
@@ -73,5 +73,162 @@ describe('TodoFilters', () => {
 
     fireEvent.click(getByText('Open'));
     expect(onStatusChange).toHaveBeenCalledWith('open');
+  });
+
+  describe('Saved Views', () => {
+    const mockViews: SavedFilterView[] = [
+      { id: 'v1', name: 'High Priority', search: '', priority: 'high', status: 'all' },
+      { id: 'v2', name: 'Today', search: '', priority: 'all', status: 'open' },
+      { id: 'v3', name: 'Blockchain', search: 'blockchain', priority: 'all', status: 'all' },
+    ];
+
+    it('renders saved views when provided', () => {
+      const { getByText } = render(
+        <TodoFilters
+          search=""
+          onSearchChange={() => {}}
+          priority="all"
+          onPriorityChange={() => {}}
+          status="all"
+          onStatusChange={() => {}}
+          savedViews={mockViews}
+        />,
+      );
+
+      expect(getByText('High Priority')).toBeInTheDocument();
+      expect(getByText('Today')).toBeInTheDocument();
+      expect(getByText('Blockchain')).toBeInTheDocument();
+    });
+
+    it('calls onSelectView when a saved view button is clicked', () => {
+      const onSelectView = jest.fn();
+      const { getByText } = render(
+        <TodoFilters
+          search=""
+          onSearchChange={() => {}}
+          priority="all"
+          onPriorityChange={() => {}}
+          status="all"
+          onStatusChange={() => {}}
+          savedViews={mockViews}
+          onSelectView={onSelectView}
+        />,
+      );
+
+      fireEvent.click(getByText('High Priority'));
+      expect(onSelectView).toHaveBeenCalledWith(mockViews[0]);
+    });
+
+    it('highlights the active saved view', () => {
+      const { getByText } = render(
+        <TodoFilters
+          search=""
+          onSearchChange={() => {}}
+          priority="all"
+          onPriorityChange={() => {}}
+          status="all"
+          onStatusChange={() => {}}
+          savedViews={mockViews}
+          activeViewId="v2"
+          onSelectView={() => {}}
+        />,
+      );
+
+      // The active view button should have 'default' variant; we check it's rendered
+      const todayButton = getByText('Today');
+      expect(todayButton).toBeInTheDocument();
+    });
+
+    it('calls onDeleteView when delete button is clicked', () => {
+      const onDeleteView = jest.fn();
+      const { getByLabelText } = render(
+        <TodoFilters
+          search=""
+          onSearchChange={() => {}}
+          priority="all"
+          onPriorityChange={() => {}}
+          status="all"
+          onStatusChange={() => {}}
+          savedViews={mockViews}
+          onDeleteView={onDeleteView}
+        />,
+      );
+
+      fireEvent.click(getByLabelText('Delete saved view Today'));
+      expect(onDeleteView).toHaveBeenCalledWith('v2');
+    });
+
+    it('shows save view input when there are active filters and onSaveView is provided', () => {
+      const { getByPlaceholderText, getByText } = render(
+        <TodoFilters
+          search="test"
+          onSearchChange={() => {}}
+          priority="all"
+          onPriorityChange={() => {}}
+          status="all"
+          onStatusChange={() => {}}
+          onSaveView={() => {}}
+        />,
+      );
+
+      expect(getByPlaceholderText('View name...')).toBeInTheDocument();
+      expect(getByText('Save view')).toBeInTheDocument();
+    });
+
+    it('does not show save view input when no active filters', () => {
+      const { queryByPlaceholderText } = render(
+        <TodoFilters
+          search=""
+          onSearchChange={() => {}}
+          priority="all"
+          onPriorityChange={() => {}}
+          status="all"
+          onStatusChange={() => {}}
+          onSaveView={() => {}}
+        />,
+      );
+
+      expect(queryByPlaceholderText('View name...')).not.toBeInTheDocument();
+    });
+
+    it('calls onSaveView with the entered name', () => {
+      const onSaveView = jest.fn();
+      const { getByPlaceholderText, getByText } = render(
+        <TodoFilters
+          search="test"
+          onSearchChange={() => {}}
+          priority="high"
+          onPriorityChange={() => {}}
+          status="all"
+          onStatusChange={() => {}}
+          onSaveView={onSaveView}
+        />,
+      );
+
+      fireEvent.change(getByPlaceholderText('View name...'), { target: { value: 'My View' } });
+      fireEvent.click(getByText('Save view'));
+      expect(onSaveView).toHaveBeenCalledWith('My View');
+    });
+
+    it('clears the active view when clearing filters if onClear is provided', () => {
+      const onClear = jest.fn();
+      const { getByText } = render(
+        <TodoFilters
+          search="test"
+          onSearchChange={() => {}}
+          priority="high"
+          onPriorityChange={() => {}}
+          status="open"
+          onStatusChange={() => {}}
+          onClear={onClear}
+          savedViews={mockViews}
+          activeViewId="v1"
+        />,
+      );
+
+      fireEvent.click(getByText('Clear filters'));
+      // Clear filters triggers onSearchChange(''), onPriorityChange('all'), onStatusChange('all'), onClear?.()
+      expect(onClear).toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/components/todo/index.ts
+++ b/apps/web/src/components/todo/index.ts
@@ -1,12 +1,12 @@
 export { TodoForm, todoFormVariants, type TodoFormData, type TodoFormProps } from './TodoForm';
 export { TodoItem, todoItemVariants, type TodoData, type TodoItemProps } from './TodoItem';
+export { TodoList, todoListVariants, type TodoListProps, type TodoListStats, type FilterType } from './TodoList';
 export {
-  TodoList,
-  todoListVariants,
-  type TodoListProps,
-  type TodoListStats,
-  type FilterType,
+  TodoFilters,
+  type TodoFiltersProps,
+  type PriorityFilter,
+  type StatusFilter,
+  type SavedFilterView,
   type SortType,
-} from './TodoList';
-export { TodoFilters, type TodoFiltersProps, type PriorityFilter, type StatusFilter } from './TodoFilters';
+} from './TodoFilters';
 export { TodoBulkActions, type TodoBulkActionsProps } from './TodoBulkActions';

--- a/apps/web/src/store/todoStore.ts
+++ b/apps/web/src/store/todoStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { TodoData as Todo } from '@/components/todo/TodoItem';
+import type { SavedFilterView } from '@/components/todo/TodoFilters';
 import { createBlockchainService, todoToBlockchainTodo, type TransactionResult } from '@/services/blockchainService';
 import type { BlockchainNetwork, ApiTodo, ApiResponse } from '@todo/services';
 import { todoClient } from '@/config/api';
@@ -11,6 +12,7 @@ interface TodoStore {
   error: string | null;
   undoStack: Todo[][];
   canUndo: boolean;
+  savedViews: SavedFilterView[];
 
   // Actions
   addTodo: (_todoData: Omit<Todo, 'id' | 'createdAt' | 'updatedAt' | 'userId'>) => void;
@@ -21,6 +23,8 @@ interface TodoStore {
   clearCompleted: () => void;
   undo: () => void;
   syncToBlockchain: (_todoId: string, _selectedNetwork: BlockchainNetwork) => Promise<void>;
+  addSavedView: (_view: Omit<SavedFilterView, 'id'>) => void;
+  deleteSavedView: (_id: string) => void;
 
   // API actions (will be implemented when API is ready)
   fetchTodos: () => Promise<void>;
@@ -43,6 +47,7 @@ export const useTodoStore = create<TodoStore>()(
       error: null,
       undoStack: [],
       canUndo: false,
+      savedViews: [],
 
       addTodo: todoData => {
         const newTodo: Todo = {
@@ -261,10 +266,26 @@ export const useTodoStore = create<TodoStore>()(
           });
         }
       },
+
+      addSavedView: view => {
+        const newView: SavedFilterView = {
+          ...view,
+          id: Date.now().toString(36) + Math.random().toString(36).substr(2, 5),
+        };
+        set(state => ({
+          savedViews: [...state.savedViews, newView],
+        }));
+      },
+
+      deleteSavedView: id => {
+        set(state => ({
+          savedViews: state.savedViews.filter(v => v.id !== id),
+        }));
+      },
     }),
     {
       name: 'todo-storage',
-      partialize: state => ({ todos: state.todos }),
+      partialize: state => ({ todos: state.todos, savedViews: state.savedViews }),
     },
   ),
 );


### PR DESCRIPTION
## Summary

Add saved todo filter views to the web todo application, allowing users to save, select, and delete named filter presets.

> **Provenance**: HOCA-manager-owned replacement for [untrusted PR #101](https://github.com/kaybarax/todo-list-turborepo/pull/101). All changes reviewed and reproduced from the original scope. Author: Kaybarax.

## Changes

- **TodoFilters**: New `SavedFilterView` interface + `SortType` type. Saved views display as pill buttons above the filter controls. "Save view" input appears when active filters are set.
- **TodoList**: Saved views rendered in the controls panel; clicking a view applies its filter/sort/search config.
- **page.tsx**: `activeViewId` state tracks the selected view; handlers for select/save/delete; manual filter change clears active view.
- **todoStore**: `savedViews` array persisted alongside todos; `addSavedView`/`deleteSavedView` actions.
- **Tests**: 10 new saved-view test cases across `TodoFilters` and `TodoList`.

## Files touched

`apps/web/src/app/todos/page.tsx`
`apps/web/src/components/todo/TodoFilters.tsx`
`apps/web/src/components/todo/TodoList.tsx`
`apps/web/src/components/todo/index.ts`
`apps/web/src/components/index.ts`
`apps/web/src/store/todoStore.ts`
`apps/web/src/components/todo/__tests__/TodoFilters.test.tsx`
`apps/web/src/components/__tests__/TodoList.test.tsx`